### PR TITLE
feat(studio): add build version and commit SHA tracking to Docker image

### DIFF
--- a/.changeset/bright-clouds-dance.md
+++ b/.changeset/bright-clouds-dance.md
@@ -1,0 +1,5 @@
+---
+'@loopstack/loopstack-studio': patch
+---
+
+Add build version and commit SHA tracking to Docker image

--- a/.github/workflows/release-studio-docker.yml
+++ b/.github/workflows/release-studio-docker.yml
@@ -80,6 +80,9 @@ jobs:
           push: true
           tags: ${{ steps.meta-stable.outputs.tags }}
           labels: ${{ steps.meta-stable.outputs.labels }}
+          build-args: |
+            COMMIT_SHA=${{ github.sha }}
+            VERSION=${{ steps.version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           provenance: false

--- a/docker-compose.infra.yml
+++ b/docker-compose.infra.yml
@@ -1,3 +1,5 @@
+name: loopstack
+
 services:
   postgres:
     image: postgres:16-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+name: loopstack
+
 services:
   postgres:
     image: postgres:16-alpine

--- a/frontend/studio/Dockerfile
+++ b/frontend/studio/Dockerfile
@@ -1,10 +1,17 @@
 FROM node:20-alpine AS build
 WORKDIR /app
 
+ARG COMMIT_SHA=unknown
+ARG VERSION=unknown
+
 COPY package.json package-lock.json* ./
 RUN npm install
 
 COPY . .
+
+ENV VITE_COMMIT_SHA=${COMMIT_SHA}
+ENV VITE_APP_VERSION=${VERSION}
+
 RUN npm run build:prod
 
 FROM node:20-alpine AS production

--- a/frontend/studio/src/config.ts
+++ b/frontend/studio/src/config.ts
@@ -19,6 +19,10 @@ const config = {
     name: 'Local Environment',
     url: apiUrl,
   } as Environment,
+  build: {
+    version: (import.meta.env.VITE_APP_VERSION as string | undefined) ?? 'dev',
+    commitSha: (import.meta.env.VITE_COMMIT_SHA as string | undefined) ?? 'dev',
+  },
 };
 
 export default config;

--- a/frontend/studio/src/main.tsx
+++ b/frontend/studio/src/main.tsx
@@ -5,7 +5,10 @@ import '@fontsource/roboto/700.css';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
+import config from './config.ts';
 import './styles.css';
+
+console.info(`[loopstack-studio] v${config.build.version} (${config.build.commitSha.slice(0, 8)})`);
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>


### PR DESCRIPTION
- Pass COMMIT_SHA and VERSION as Docker build args in CI workflow
- Inject version/commit into Vite build via env vars
- Log version info to browser console on startup
- Add 'name: loopstack' to docker-compose files