### PR TITLE
ci: only run on PRs targeting main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,12 @@
 # ============================================================================
-# CI Workflow - Runs on PRs to develop and main
+# CI Workflow - Runs on PRs to main
 # ============================================================================
 
 name: CI
 
 on:
   pull_request:
-    branches: [develop, main]
+    branches: [main]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Drop `develop` from the pull_request.branches list so CI no longer runs on PRs into develop. workflow_dispatch is kept so the workflow can still be triggered manually on any branch.

Closes #203