### PR TITLE
fix(remote-client): allow bare RemoteClientModule import

### DIFF
--- a/.changeset/bare-remote-client-import.md
+++ b/.changeset/bare-remote-client-import.md
@@ -1,0 +1,5 @@
+---
+'@loopstack/remote-client': patch
+---
+
+Allow bare `RemoteClientModule` import without `forRoot()`. The module's static `@Module` decorator now wires a global root module, so importing the class directly registers `RemoteClient`, `EnvironmentService`, `EnvironmentConfigService`, `ENVIRONMENT_CONFIG`, and the file/exec tools with default config. `forRoot(options)` and `forFeature(options)` are unchanged.

--- a/registry/features/remote-client-module/src/__tests__/remote-client.module.spec.ts
+++ b/registry/features/remote-client-module/src/__tests__/remote-client.module.spec.ts
@@ -1,0 +1,78 @@
+import { type DynamicModule, Module, type Type } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { describe, expect, it, vi } from 'vitest';
+import { ENVIRONMENT_CONFIG } from '@loopstack/common';
+
+// TypeOrmModule.forFeature creates real repository providers that explode without a DataSource.
+// Stub it so the test can focus on RemoteClientModule's own wiring (RemoteClient, env config).
+vi.mock(import('@nestjs/typeorm'), async (importOriginal) => {
+  const actual = await importOriginal();
+  @Module({})
+  class StubTypeOrmModule {}
+  return {
+    ...actual,
+    TypeOrmModule: {
+      ...actual.TypeOrmModule,
+      forFeature: (): DynamicModule => ({ module: StubTypeOrmModule, providers: [], exports: [] }),
+    },
+  };
+});
+
+const { RemoteClientModule } = await import('../remote-client.module.js');
+const { EnvironmentConfigService } = await import('../services/environment-config.service.js');
+const { RemoteClient } = await import('../services/remote-client.service.js');
+
+// Cross-package deps (TypeORM repositories, SecretsModule internals, etc.) are out of scope —
+// we only care that RemoteClientModule wires its OWN providers correctly.
+// useMocker stubs any unresolved injection token with an empty object.
+function build(imports: Array<Type<unknown> | DynamicModule>) {
+  return Test.createTestingModule({ imports })
+    .useMocker(() => ({}))
+    .compile();
+}
+
+describe('RemoteClientModule import forms', () => {
+  it('bare import registers RemoteClient and applies the default empty available list globally', async () => {
+    const moduleRef = await build([RemoteClientModule]);
+
+    expect(moduleRef.get(RemoteClient, { strict: false })).toBeInstanceOf(RemoteClient);
+    const config = moduleRef.get(ENVIRONMENT_CONFIG, { strict: false }) as EnvironmentConfigService;
+    expect(config).toBeInstanceOf(EnvironmentConfigService);
+    expect(config.available).toEqual([]);
+
+    await moduleRef.close();
+  });
+
+  it('forRoot() registers RemoteClient and applies an empty available list globally', async () => {
+    const moduleRef = await build([RemoteClientModule.forRoot()]);
+
+    expect(moduleRef.get(RemoteClient, { strict: false })).toBeInstanceOf(RemoteClient);
+    const config = moduleRef.get(ENVIRONMENT_CONFIG, { strict: false }) as EnvironmentConfigService;
+    expect(config.available).toEqual([]);
+
+    await moduleRef.close();
+  });
+
+  it('forRoot(options) makes the configured available environments visible everywhere', async () => {
+    const available = [{ type: 'docker', name: 'Docker', connectionUrl: 'http://localhost:3001' }];
+    const moduleRef = await build([RemoteClientModule.forRoot({ environments: { available } })]);
+
+    const config = moduleRef.get(ENVIRONMENT_CONFIG, { strict: false }) as EnvironmentConfigService;
+    expect(config.available).toEqual(available);
+
+    await moduleRef.close();
+  });
+
+  it('bare import alongside forRoot(options) — forRoot wins (bare import is a no-op overlap)', async () => {
+    // Edge case: a user could write both bare and forRoot(options) in the same imports list
+    // (e.g. via a refactor). We don't endorse this combination, but verify it doesn't silently
+    // shadow the explicit forRoot config with the bare import's default.
+    const available = [{ type: 'docker', name: 'Docker', connectionUrl: 'http://localhost:3001' }];
+    const moduleRef = await build([RemoteClientModule, RemoteClientModule.forRoot({ environments: { available } })]);
+
+    const config = moduleRef.get(ENVIRONMENT_CONFIG, { strict: false }) as EnvironmentConfigService;
+    expect(config.available).toEqual(available);
+
+    await moduleRef.close();
+  });
+});

--- a/registry/features/remote-client-module/src/remote-client.module.ts
+++ b/registry/features/remote-client-module/src/remote-client.module.ts
@@ -1,4 +1,4 @@
-import { type DynamicModule, Module } from '@nestjs/common';
+import { type DynamicModule, Global, Module, type Provider } from '@nestjs/common';
 import { DiscoveryModule, DiscoveryService } from '@nestjs/core';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ENVIRONMENT_CONFIG, WorkspaceEntity, registerStudioExtension } from '@loopstack/common';
@@ -45,34 +45,64 @@ const TOOLS = [
   SyncSecretsTool,
 ];
 
-@Module({})
+const SHARED_IMPORTS = [
+  DiscoveryModule,
+  SecretsModule,
+  TypeOrmModule.forFeature([WorkspaceEntity, WorkspaceEnvironmentEntity]),
+];
+
+const ROOT_EXPORTS = [RemoteClient, EnvironmentService, EnvironmentConfigService, ENVIRONMENT_CONFIG, ...TOOLS];
+
+function environmentConfigProvider(available?: AvailableEnvironmentInterface[]): Provider {
+  return {
+    provide: EnvironmentConfigService,
+    useFactory: (discoveryService: DiscoveryService) => new EnvironmentConfigService(discoveryService, available),
+    inject: [DiscoveryService],
+  };
+}
+
+function rootProviders(options?: RemoteClientModuleOptions): Provider[] {
+  return [
+    RemoteClient,
+    EnvironmentService,
+    environmentConfigProvider(options?.environments?.available),
+    { provide: ENVIRONMENT_CONFIG, useExisting: EnvironmentConfigService },
+    ...TOOLS,
+  ];
+}
+
+/**
+ * Internal global root module — provides RemoteClient, environment services, and
+ * default tools globally with empty defaults. Separate class from RemoteClientModule
+ * so a bare import boots a working container and forRoot() can override config
+ * without conflicting with forFeature() imports.
+ */
+@Global()
+@Module({
+  imports: SHARED_IMPORTS,
+  controllers: [EnvironmentController],
+  providers: rootProviders(),
+  exports: ROOT_EXPORTS,
+})
+class RemoteClientRootModule {}
+
+/**
+ * Remote Client Module — wires the RemoteClient and environment tools.
+ *
+ * - Bare import (`RemoteClientModule`) — registers the global root with default config.
+ * - `forRoot(options)` — sets the global config (e.g. available environments).
+ * - `forFeature(options)` — registers environment slots for the current module.
+ */
+@Module({ imports: [RemoteClientRootModule] })
 export class RemoteClientModule {
   static forRoot(options?: RemoteClientModuleOptions): DynamicModule {
     return {
+      module: RemoteClientRootModule,
       global: true,
-      module: RemoteClientModule,
-      imports: [
-        DiscoveryModule,
-        SecretsModule,
-        TypeOrmModule.forFeature([WorkspaceEntity, WorkspaceEnvironmentEntity]),
-      ],
+      imports: SHARED_IMPORTS,
       controllers: [EnvironmentController],
-      providers: [
-        RemoteClient,
-        EnvironmentService,
-        {
-          provide: EnvironmentConfigService,
-          useFactory: (discoveryService: DiscoveryService) =>
-            new EnvironmentConfigService(discoveryService, options?.environments?.available),
-          inject: [DiscoveryService],
-        },
-        {
-          provide: ENVIRONMENT_CONFIG,
-          useExisting: EnvironmentConfigService,
-        },
-        ...TOOLS,
-      ],
-      exports: [RemoteClient, EnvironmentService, EnvironmentConfigService, ENVIRONMENT_CONFIG, ...TOOLS],
+      providers: rootProviders(options),
+      exports: ROOT_EXPORTS,
     };
   }
 


### PR DESCRIPTION
Mirror the LlmProviderModule fix from #187: move the actual wiring onto an internal `@Global() RemoteClientRootModule` and have `RemoteClientModule`'s static `@Module` decorator import the root.

Bare `RemoteClientModule` imports now boot with `RemoteClient`, `EnvironmentService`, `EnvironmentConfigService`, `ENVIRONMENT_CONFIG`, and the file/exec tools registered globally. `forRoot(options)` overrides the global config (available environments) and `forFeature(options)` is unchanged.

Closes #202