### PR TITLE
feat(common): rename MessageDocument.content to text, separate from LLM history

### DIFF
--- a/.changeset/message-document-text-rename.md
+++ b/.changeset/message-document-text-rename.md
@@ -1,0 +1,24 @@
+---
+'@loopstack/common': minor
+'@loopstack/llm-provider-module': patch
+'@loopstack/loopstack-studio': patch
+'@loopstack/accessing-tool-results-example-workflow': patch
+'@loopstack/agent-example-workflow': patch
+'@loopstack/code-agent-example-workflow': patch
+'@loopstack/custom-tool-example-module': patch
+'@loopstack/delegate-error-example-workflow': patch
+'@loopstack/dynamic-routing-example-workflow': patch
+'@loopstack/error-retry-example-workflow': patch
+'@loopstack/git-commit-flow-example-workflow': patch
+'@loopstack/hitl-ask-user-example-workflow': patch
+'@loopstack/hitl-confirm-example-workflow': patch
+'@loopstack/mcp-linear-example-workflow': patch
+'@loopstack/module-config-example': patch
+'@loopstack/remote-file-explorer-example-workflow': patch
+'@loopstack/run-sub-workflow-example': patch
+'@loopstack/sandbox-example-workflow': patch
+'@loopstack/test-ui-documents-example-workflow': patch
+'@loopstack/workflow-state-example-workflow': patch
+---
+
+`MessageDocument`'s field is renamed `content: string` → `text?: string` so it lines up with `LlmMessageDocument`, and its default tag changes from `['message']` to `['ui-message']`. The tag change means a `MessageDocument` is no longer picked up by LLM history collection (`messagesSearchTag` defaults to `'message'`) — plain UI bubbles stop leaking into the conversation context. `LlmMessageDocument` now extends `MessageDocument` for a shared base; its exposed fields (`role`, `text`, `blocks`, `stopReason`, `id`) are unchanged. To restore the old behaviour and feed a `MessageDocument` into LLM history, save it with explicit `tags: ['message']`.

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ export class HelloWorkflow extends BaseWorkflow<InputArgs> {
   async saveMessage() {
     await this.documentStore.save(LlmMessageDocument, {
       role: 'assistant',
-      content: 'Bye.',
+      text: 'Bye.',
     });
   }
 }

--- a/docs/build/fundamentals/documents.md
+++ b/docs/build/fundamentals/documents.md
@@ -136,15 +136,15 @@ These are available without creating custom documents:
 | -------------------- | -------------------------------- | ---------------------------------------------------- |
 | `LlmMessageDocument` | `@loopstack/llm-provider-module` | `role`, `text`, `blocks`                             |
 | `LinkDocument`       | `@loopstack/common`              | `label`, `workflowId`, `status`, `embed`, `expanded` |
-| `MessageDocument`    | `@loopstack/common`              | `role`, `content`                                    |
+| `MessageDocument`    | `@loopstack/common`              | `role`, `text`                                       |
 | `MarkdownDocument`   | `@loopstack/common`              | `markdown`                                           |
 | `PlainDocument`      | `@loopstack/common`              | `text`                                               |
 | `ErrorDocument`      | `@loopstack/common`              | `error`                                              |
 
 ### Choosing the right built-in type
 
-- **`LlmMessageDocument`** — assistant/user conversation turns. The LLM provider tools (e.g. `LlmGenerateTextTool`) save these automatically; you only save them manually to seed system messages or inject synthetic turns.
-- **`MessageDocument`** — generic role/content messages for non-LLM chat-style flows (e.g. logging a `system` note, a `user` confirmation). Same shape as `LlmMessageDocument` but not LLM-aware.
+- **`LlmMessageDocument`** — assistant/user conversation turns. Extends `MessageDocument` with structured `blocks` (tool calls, thinking, tool results) and an LLM `stopReason`. Tagged `'message'`, so it's automatically collected into LLM conversation history. Save manually to seed system messages or inject synthetic turns; the LLM provider tools save these for you in normal use.
+- **`MessageDocument`** — plain `{ role, text }` UI bubbles for non-LLM flows (status updates, narrative output, logging a `system` note). Tagged `'ui-message'` — **not** collected into LLM history. Use this when you want a chat-style message in Studio without polluting the LLM's context.
 - **`MarkdownDocument`** — formatted prose, headings, lists, links. Use when you want Studio to render rich text.
 - **`PlainDocument`** — unformatted text output: raw command output, log dumps, plain blob. Use when Markdown rendering would interpret characters you want shown literally.
 - **`LinkDocument`** — links to other workflow runs (sub-workflows, related runs). Studio renders these as inline cards with status indicators.

--- a/docs/build/patterns/dynamic-routing.md
+++ b/docs/build/patterns/dynamic-routing.md
@@ -56,7 +56,7 @@ export class DynamicRoutingExampleWorkflow extends BaseWorkflow<{ value: number 
     const args = ctx.args as { value: number };
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `Analysing value = ${args.value}`,
+      text: `Analysing value = ${args.value}`,
     });
     return { ...state, value: args.value };
   }
@@ -96,13 +96,13 @@ export class DynamicRoutingExampleWorkflow extends BaseWorkflow<{ value: number 
   // Terminal transitions
   @Transition({ from: 'placeB', to: 'end' })
   async showMessagePlaceB(state: RoutingState): Promise<unknown> {
-    await this.documentStore.save(MessageDocument, { role: 'assistant', content: 'Value is less or equal 100' });
+    await this.documentStore.save(MessageDocument, { role: 'assistant', text: 'Value is less or equal 100' });
     return {};
   }
 
   @Transition({ from: 'placeC', to: 'end' })
   async showMessagePlaceC(state: RoutingState): Promise<unknown> {
-    await this.documentStore.save(MessageDocument, { role: 'assistant', content: 'Value is greater than 200' });
+    await this.documentStore.save(MessageDocument, { role: 'assistant', text: 'Value is greater than 200' });
     return {};
   }
 
@@ -110,7 +110,7 @@ export class DynamicRoutingExampleWorkflow extends BaseWorkflow<{ value: number 
   async showMessagePlaceD(state: RoutingState): Promise<unknown> {
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: 'Value is less or equal 200, but greater than 100',
+      text: 'Value is less or equal 200, but greater than 100',
     });
     return {};
   }

--- a/docs/build/patterns/error-handling.md
+++ b/docs/build/patterns/error-handling.md
@@ -37,7 +37,7 @@ async handleProcessingError() {
   // Recovery logic — user clicks a "Recover" button to trigger this
   await this.documentStore.save(MessageDocument, {
     role: 'assistant',
-    content: 'Processing failed. Retrying with fallback strategy.',
+    text: 'Processing failed. Retrying with fallback strategy.',
   });
 }
 ```

--- a/docs/build/patterns/state-management.md
+++ b/docs/build/patterns/state-management.md
@@ -65,7 +65,7 @@ Access state in any transition or guard method:
 async display(state: MyState): Promise<unknown> {
   await this.documentStore.save(MessageDocument, {
     role: 'assistant',
-    content: `Processed ${state.counter} items. Result: ${state.llmResult?.content}`,
+    text: `Processed ${state.counter} items. Result: ${state.llmResult?.text}`,
   });
   return {};
 }
@@ -120,7 +120,7 @@ export class MyWorkflow extends BaseWorkflow<Record<string, unknown>, MyState> {
   async showResults(state: MyState): Promise<unknown> {
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: this.formatMessage(state.message!),
+      text: this.formatMessage(state.message!),
     });
     return {};
   }

--- a/docs/build/patterns/sub-workflows.md
+++ b/docs/build/patterns/sub-workflows.md
@@ -61,7 +61,7 @@ async onSubComplete(state: MyState, payload: { workflowId: string; status: strin
 
   await this.documentStore.save(MessageDocument, {
     role: 'assistant',
-    content: `Sub-workflow said: ${payload.data.message}`,
+    text: `Sub-workflow said: ${payload.data.message}`,
   });
   return state;
 }
@@ -127,7 +127,7 @@ export class ParentWorkflow extends BaseWorkflow {
 
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `Message from sub-workflow: ${payload.data.message}`,
+      text: `Message from sub-workflow: ${payload.data.message}`,
     });
     return {};
   }

--- a/docs/learn/document-store.md
+++ b/docs/learn/document-store.md
@@ -110,12 +110,14 @@ await this.documentStore.save(OptimizedNotesDocument, llmResult.data, { id: 'not
 
 ## Documents as LLM Context
 
-The document store is also the LLM's memory. When you call an LLM tool without an explicit prompt, it scans the document store for all `LlmMessageDocument` records in the current run and builds the conversation history automatically:
+The document store is also the LLM's memory. When you call an LLM tool without an explicit prompt, it scans the document store for all documents tagged `'message'` in the current run and builds the conversation history automatically. `LlmMessageDocument` carries this tag by default; `MessageDocument` does not, so plain UI bubbles never leak into the LLM context.
 
 ```typescript
 // No prompt — LLM reads all LlmMessageDocument records as history
 const result = await this.llmGenerateText.call({}, { config: { provider: 'claude', model: 'claude-sonnet-4-6' } });
 ```
+
+> **Want a `MessageDocument` to feed into history too?** Save it with an explicit `tags: ['message']` override, or change the search tag via the tool's `messagesSearchTag` config. By default they're UI-only.
 
 The LLM sees the messages in the order they were saved — user messages, assistant responses, tool calls, tool results. Adding a new user message to the document store before calling the LLM is how you extend the conversation:
 
@@ -144,14 +146,14 @@ await this.documentStore.save(LlmMessageDocument, { role: 'user', text: systemPr
 
 You don't always need to create custom documents. The built-in types cover the most common cases:
 
-| Document             | Source                           | Use case                                                           |
-| -------------------- | -------------------------------- | ------------------------------------------------------------------ |
-| `LlmMessageDocument` | `@loopstack/llm-provider-module` | Chat messages — user and assistant turns, tool calls, tool results |
-| `MessageDocument`    | `@loopstack/common`              | Simple role/content messages without LLM-specific fields           |
-| `MarkdownDocument`   | `@loopstack/common`              | Rich text output rendered as formatted markdown                    |
-| `PlainDocument`      | `@loopstack/common`              | Plain text output                                                  |
-| `LinkDocument`       | `@loopstack/common`              | Links to sub-workflow runs, with embed and status support          |
-| `ErrorDocument`      | `@loopstack/common`              | Error messages, automatically saved on transition failure          |
+| Document             | Source                           | Use case                                                                                                   |
+| -------------------- | -------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `LlmMessageDocument` | `@loopstack/llm-provider-module` | Chat messages — user and assistant turns, tool calls, tool results. Collected into LLM history by default. |
+| `MessageDocument`    | `@loopstack/common`              | UI-only role/text bubbles (status updates, narrative). Not collected into LLM history.                     |
+| `MarkdownDocument`   | `@loopstack/common`              | Rich text output rendered as formatted markdown                                                            |
+| `PlainDocument`      | `@loopstack/common`              | Plain text output                                                                                          |
+| `LinkDocument`       | `@loopstack/common`              | Links to sub-workflow runs, with embed and status support                                                  |
+| `ErrorDocument`      | `@loopstack/common`              | Error messages, automatically saved on transition failure                                                  |
 
 Custom documents are for when you need structured forms, interactive fields, or action buttons — see the [Creating Documents](../build/fundamentals/documents.md) guide.
 

--- a/docs/skills/create-custom-document.md
+++ b/docs/skills/create-custom-document.md
@@ -117,7 +117,7 @@ Don't redefine these — import and save:
 | -------------------- | -------------------------------- | ---------------------------------------------------- |
 | `LlmMessageDocument` | `@loopstack/llm-provider-module` | `role`, `text`, `blocks`                             |
 | `LinkDocument`       | `@loopstack/common`              | `label`, `workflowId`, `status`, `embed`, `expanded` |
-| `MessageDocument`    | `@loopstack/common`              | `role`, `content`                                    |
+| `MessageDocument`    | `@loopstack/common`              | `role`, `text`                                       |
 | `MarkdownDocument`   | `@loopstack/common`              | `markdown`                                           |
 | `PlainDocument`      | `@loopstack/common`              | `text`                                               |
 | `ErrorDocument`      | `@loopstack/common`              | `error`                                              |

--- a/docs/skills/create-custom-tool.md
+++ b/docs/skills/create-custom-tool.md
@@ -175,7 +175,7 @@ return {
 protected async handle(args: MyArgs, ctx: RunContext): Promise<ToolResult> {
   await this.documentStore.save(MessageDocument, {
     role: 'assistant',
-    content: 'Processing complete.',
+    text: 'Processing complete.',
   });
   return { data: 'done' };
 }

--- a/docs/skills/use-core-tools.md
+++ b/docs/skills/use-core-tools.md
@@ -105,7 +105,7 @@ These document types are available from `@loopstack/common` without additional i
 
 | Document           | Description                     | Key Fields                                           |
 | ------------------ | ------------------------------- | ---------------------------------------------------- |
-| `MessageDocument`  | Simple chat message             | `role`, `content`                                    |
+| `MessageDocument`  | UI-only chat message            | `role`, `text`                                       |
 | `MarkdownDocument` | Rendered markdown               | `markdown`                                           |
 | `PlainDocument`    | Plain text                      | `text`                                               |
 | `ErrorDocument`    | Error message (red styling)     | `error`                                              |
@@ -124,7 +124,7 @@ await this.documentStore.save(LinkDocument, {
 
 await this.documentStore.save(MessageDocument, {
   role: 'assistant',
-  content: 'Hello! How can I help?',
+  text: 'Hello! How can I help?',
 });
 ```
 

--- a/frontend/studio/src/features/documents/renderers/DocumentMessageRenderer.tsx
+++ b/frontend/studio/src/features/documents/renderers/DocumentMessageRenderer.tsx
@@ -1,19 +1,24 @@
 import React from 'react';
 import type { DocumentItemInterface } from '@loopstack/contracts/types';
+import MarkdownContent from '@/components/dynamic-form/MarkdownContent.tsx';
 import CompletionMessagePaper from '@/components/messages/CompletionMessagePaper.tsx';
-import type { ModelMessage } from '@/types/ai.types';
-import MessageContentRenderer from './AiMessageContent.tsx';
 
-interface DocumentMessageRendererProps {
-  document: Omit<DocumentItemInterface, 'content'> & { content: ModelMessage };
+type MessageRole = 'system' | 'user' | 'assistant' | 'tool' | 'error' | 'document';
+
+interface MessagePayload {
+  role?: string;
+  text?: string;
 }
 
-const DocumentMessageRenderer: React.FC<DocumentMessageRendererProps> = ({ document }) => {
-  const content = document.content;
+const KNOWN_ROLES: MessageRole[] = ['system', 'user', 'assistant', 'tool', 'error', 'document'];
+
+const DocumentMessageRenderer: React.FC<{ document: DocumentItemInterface }> = ({ document }) => {
+  const { role, text } = document.content as MessagePayload;
+  const renderedRole = (KNOWN_ROLES as string[]).includes(role ?? '') ? (role as MessageRole) : undefined;
 
   return (
-    <CompletionMessagePaper>
-      <MessageContentRenderer message={content} />
+    <CompletionMessagePaper role={renderedRole}>
+      <MarkdownContent content={text ?? ''} />
     </CompletionMessagePaper>
   );
 };

--- a/packages/common/src/documents/message-document.ts
+++ b/packages/common/src/documents/message-document.ts
@@ -4,16 +4,16 @@ import { Document } from '../decorators/block.decorator.js';
 export const MessageDocumentSchema = z
   .object({
     role: z.string(),
-    content: z.string(),
+    text: z.string().optional(),
   })
   .strict();
 
 @Document({
   schema: MessageDocumentSchema,
   widget: import.meta.dirname + '/message-document.yaml',
-  tags: ['message'],
+  tags: ['ui-message'],
 })
 export class MessageDocument {
   role: string;
-  content: string;
+  text?: string;
 }

--- a/registry/examples/accessing-tool-results-example-workflow/README.md
+++ b/registry/examples/accessing-tool-results-example-workflow/README.md
@@ -83,7 +83,7 @@ async createSomeData(
 ): Promise<ToolResultsState> {
   await this.documentStore.save(MessageDocument, {
     role: 'assistant',
-    content: `Stored in initial transition: Hello World.`,
+    text: `Stored in initial transition: Hello World.`,
   });
   return { ...state, storedMessage: 'Hello World.' };
 }
@@ -100,7 +100,7 @@ In a subsequent transition, read values from the `state` parameter:
 async accessData(ctx: WorkflowContext, state: ToolResultsState): Promise<unknown> {
   await this.documentStore.save(MessageDocument, {
     role: 'assistant',
-    content: `Accessed from previous transition: ${state.storedMessage}`,
+    text: `Accessed from previous transition: ${state.storedMessage}`,
   });
   return {};
 }
@@ -133,7 +133,7 @@ export class WorkflowToolResultsWorkflow extends BaseWorkflow<Record<string, unk
   ): Promise<ToolResultsState> {
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `Stored in initial transition: Hello World.`,
+      text: `Stored in initial transition: Hello World.`,
     });
     return { ...state, storedMessage: 'Hello World.' };
   }
@@ -142,7 +142,7 @@ export class WorkflowToolResultsWorkflow extends BaseWorkflow<Record<string, unk
   async accessData(ctx: WorkflowContext, state: ToolResultsState): Promise<unknown> {
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `Accessed from previous transition: ${state.storedMessage}`,
+      text: `Accessed from previous transition: ${state.storedMessage}`,
     });
     return {};
   }

--- a/registry/examples/accessing-tool-results-example-workflow/src/__tests__/workflow-tool-results.workflow.spec.ts
+++ b/registry/examples/accessing-tool-results-example-workflow/src/__tests__/workflow-tool-results.workflow.spec.ts
@@ -37,7 +37,7 @@ describe('WorkflowToolResultsWorkflow', () => {
             documentName: 'message',
             content: expect.objectContaining({
               role: 'assistant',
-              content: 'Stored in initial transition: Hello World.',
+              text: 'Stored in initial transition: Hello World.',
             }),
           }),
         ]),
@@ -56,7 +56,7 @@ describe('WorkflowToolResultsWorkflow', () => {
             documentName: 'message',
             content: expect.objectContaining({
               role: 'assistant',
-              content: 'Accessed from previous transition: Hello World.',
+              text: 'Accessed from previous transition: Hello World.',
             }),
           }),
         ]),

--- a/registry/examples/accessing-tool-results-example-workflow/src/workflow-tool-results.workflow.ts
+++ b/registry/examples/accessing-tool-results-example-workflow/src/workflow-tool-results.workflow.ts
@@ -12,7 +12,7 @@ export class WorkflowToolResultsWorkflow extends BaseWorkflow<Record<string, unk
   async createSomeData(state: ToolResultsState): Promise<ToolResultsState> {
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `Stored in initial transition: Hello World.`,
+      text: `Stored in initial transition: Hello World.`,
     });
     return { ...state, storedMessage: 'Hello World.' };
   }
@@ -21,7 +21,7 @@ export class WorkflowToolResultsWorkflow extends BaseWorkflow<Record<string, unk
   async accessData(state: ToolResultsState): Promise<unknown> {
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `Accessed from previous transition: ${state.storedMessage}`,
+      text: `Accessed from previous transition: ${state.storedMessage}`,
     });
     return {};
   }

--- a/registry/examples/agent-example-workflow/src/__tests__/agent-example.workflow.spec.ts
+++ b/registry/examples/agent-example-workflow/src/__tests__/agent-example.workflow.spec.ts
@@ -89,7 +89,7 @@ describe('AgentExampleWorkflow', () => {
       expect.arrayContaining([
         expect.objectContaining({
           documentName: 'message',
-          content: expect.objectContaining({ content: expect.stringContaining('714') }),
+          content: expect.objectContaining({ text: expect.stringContaining('714') }),
         }),
       ]),
     );

--- a/registry/examples/agent-example-workflow/src/agent-example.workflow.ts
+++ b/registry/examples/agent-example-workflow/src/agent-example.workflow.ts
@@ -59,7 +59,7 @@ export class AgentExampleWorkflow extends BaseWorkflow {
 
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: payload.data.response,
+      text: payload.data.response,
     });
     return {};
   }

--- a/registry/examples/code-agent-example-workflow/src/__tests__/code-agent-example.workflow.spec.ts
+++ b/registry/examples/code-agent-example-workflow/src/__tests__/code-agent-example.workflow.spec.ts
@@ -86,7 +86,7 @@ describe('CodeAgentExampleWorkflow', () => {
       expect.arrayContaining([
         expect.objectContaining({
           documentName: 'message',
-          content: expect.objectContaining({ content: expect.stringContaining('AppModule') }),
+          content: expect.objectContaining({ text: expect.stringContaining('AppModule') }),
         }),
       ]),
     );

--- a/registry/examples/code-agent-example-workflow/src/code-agent-example.workflow.ts
+++ b/registry/examples/code-agent-example-workflow/src/code-agent-example.workflow.ts
@@ -61,7 +61,7 @@ export class CodeAgentExampleWorkflow extends BaseWorkflow {
 
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: payload.data.response,
+      text: payload.data.response,
     });
     return {};
   }

--- a/registry/examples/custom-tool-example-module/README.md
+++ b/registry/examples/custom-tool-example-module/README.md
@@ -185,12 +185,12 @@ async calculate(
 
   await this.documentStore.save(MessageDocument, {
     role: 'assistant',
-    content: `Tool calculation result:\n${args.a} + ${args.b} = ${total}`,
+    text: `Tool calculation result:\n${args.a} + ${args.b} = ${total}`,
   });
 
   await this.documentStore.save(MessageDocument, {
     role: 'assistant',
-    content: `Alternatively, using workflow method:\n${args.a} + ${args.b} = ${this.sum(args.a, args.b)}`,
+    text: `Alternatively, using workflow method:\n${args.a} + ${args.b} = ${this.sum(args.a, args.b)}`,
   });
 
   return { ...state, total };
@@ -210,7 +210,7 @@ const c3 = await this.counterTool.call();
 
 await this.documentStore.save(MessageDocument, {
   role: 'assistant',
-  content: `Counter before pause: ${c1.data}, ${c2.data}, ${c3.data}\n\nPress Next to continue...`,
+  text: `Counter before pause: ${c1.data}, ${c2.data}, ${c3.data}\n\nPress Next to continue...`,
 });
 ```
 
@@ -240,7 +240,7 @@ async continueCount(ctx: WorkflowContext, state: CustomToolExampleState): Promis
 
   await this.documentStore.save(MessageDocument, {
     role: 'assistant',
-    content: `Counter after resume: ${c4.data}, ${c5.data}, ${c6.data}\n\nIf state persisted, this should be 4, 5, 6.`,
+    text: `Counter after resume: ${c4.data}, ${c5.data}, ${c6.data}\n\nIf state persisted, this should be 4, 5, 6.`,
   });
 
   return { total: state.total };
@@ -303,12 +303,12 @@ export class CustomToolExampleWorkflow extends BaseWorkflow<{ a: number; b: numb
 
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `Tool calculation result:\n${args.a} + ${args.b} = ${total}`,
+      text: `Tool calculation result:\n${args.a} + ${args.b} = ${total}`,
     });
 
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `Alternatively, using workflow method:\n${args.a} + ${args.b} = ${this.sum(args.a, args.b)}`,
+      text: `Alternatively, using workflow method:\n${args.a} + ${args.b} = ${this.sum(args.a, args.b)}`,
     });
 
     const c1 = await this.counterTool.call();
@@ -317,7 +317,7 @@ export class CustomToolExampleWorkflow extends BaseWorkflow<{ a: number; b: numb
 
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `Counter before pause: ${c1.data}, ${c2.data}, ${c3.data}\n\nPress Next to continue...`,
+      text: `Counter before pause: ${c1.data}, ${c2.data}, ${c3.data}\n\nPress Next to continue...`,
     });
     return { ...state, total };
   }
@@ -335,7 +335,7 @@ export class CustomToolExampleWorkflow extends BaseWorkflow<{ a: number; b: numb
 
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `Counter after resume: ${c4.data}, ${c5.data}, ${c6.data}\n\nIf state persisted, this should be 4, 5, 6.`,
+      text: `Counter after resume: ${c4.data}, ${c5.data}, ${c6.data}\n\nIf state persisted, this should be 4, 5, 6.`,
     });
 
     return { total: state.total };

--- a/registry/examples/custom-tool-example-module/src/workflows/__tests__/custom-tool-example-workflow.spec.ts
+++ b/registry/examples/custom-tool-example-module/src/workflows/__tests__/custom-tool-example-workflow.spec.ts
@@ -112,7 +112,7 @@ describe('CustomToolExampleWorkflow', () => {
             documentName: 'message',
             content: expect.objectContaining({
               role: 'assistant',
-              content: expect.stringContaining('10 + 20 = 30'),
+              text: expect.stringContaining('10 + 20 = 30'),
             }),
           }),
         ]),

--- a/registry/examples/custom-tool-example-module/src/workflows/custom-tool-example.workflow.ts
+++ b/registry/examples/custom-tool-example-module/src/workflows/custom-tool-example.workflow.ts
@@ -38,13 +38,13 @@ export class CustomToolExampleWorkflow extends BaseWorkflow<{ a: number; b: numb
     // Display the result
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `Tool calculation result:\n${args.a} + ${args.b} = ${total}`,
+      text: `Tool calculation result:\n${args.a} + ${args.b} = ${total}`,
     });
 
     // Alternatively, use a custom workflow method
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `Alternatively, using workflow method:\n${args.a} + ${args.b} = ${this.sum(args.a, args.b)}`,
+      text: `Alternatively, using workflow method:\n${args.a} + ${args.b} = ${this.sum(args.a, args.b)}`,
     });
 
     // Count before pause — should be 1, 2, 3
@@ -54,7 +54,7 @@ export class CustomToolExampleWorkflow extends BaseWorkflow<{ a: number; b: numb
 
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `Counter before pause: ${c1.data}, ${c2.data}, ${c3.data}\n\nPress Next to continue...`,
+      text: `Counter before pause: ${c1.data}, ${c2.data}, ${c3.data}\n\nPress Next to continue...`,
     });
     return { ...state, total };
   }
@@ -74,7 +74,7 @@ export class CustomToolExampleWorkflow extends BaseWorkflow<{ a: number; b: numb
 
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `Counter after resume: ${c4.data}, ${c5.data}, ${c6.data}\n\nIf state persisted, this should be 4, 5, 6.`,
+      text: `Counter after resume: ${c4.data}, ${c5.data}, ${c6.data}\n\nIf state persisted, this should be 4, 5, 6.`,
     });
 
     return { total: state.total };

--- a/registry/examples/delegate-error-example-workflow/src/delegate-error.workflow.ts
+++ b/registry/examples/delegate-error-example-workflow/src/delegate-error.workflow.ts
@@ -50,7 +50,7 @@ export class DelegateErrorWorkflow extends BaseWorkflow<Record<string, unknown>,
   async setup(state: DelegateErrorState): Promise<DelegateErrorState> {
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content:
+      text:
         '# Delegate Error Handling Example\n\n' +
         'This workflow tests how tool errors are handled and fed back to the LLM.\n\n' +
         'The LLM will deliberately trigger errors, then self-correct.',

--- a/registry/examples/dynamic-routing-example-workflow/README.md
+++ b/registry/examples/dynamic-routing-example-workflow/README.md
@@ -101,7 +101,7 @@ async createMockData(
 ): Promise<DynamicRoutingState> {
   await this.documentStore.save(MessageDocument, {
     role: 'assistant',
-    content: `Analysing value = ${args.value}`,
+    text: `Analysing value = ${args.value}`,
   });
   return { ...state, value: args.value };
 }
@@ -184,7 +184,7 @@ Terminal terminal `@Transition`s save the result message:
 async showMessagePlaceB(ctx: WorkflowContext, state: DynamicRoutingState): Promise<unknown> {
   await this.documentStore.save(MessageDocument, {
     role: 'assistant',
-    content: 'Value is less or equal 100',
+    text: 'Value is less or equal 100',
   });
   return {};
 }
@@ -232,7 +232,7 @@ export class DynamicRoutingExampleWorkflow extends BaseWorkflow<{ value: number 
   ): Promise<DynamicRoutingState> {
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `Analysing value = ${args.value}`,
+      text: `Analysing value = ${args.value}`,
     });
     return { ...state, value: args.value };
   }
@@ -271,7 +271,7 @@ export class DynamicRoutingExampleWorkflow extends BaseWorkflow<{ value: number 
   async showMessagePlaceB(ctx: WorkflowContext, state: DynamicRoutingState): Promise<unknown> {
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: 'Value is less or equal 100',
+      text: 'Value is less or equal 100',
     });
     return {};
   }
@@ -280,7 +280,7 @@ export class DynamicRoutingExampleWorkflow extends BaseWorkflow<{ value: number 
   async showMessagePlaceC(ctx: WorkflowContext, state: DynamicRoutingState): Promise<unknown> {
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: 'Value is greater than 200',
+      text: 'Value is greater than 200',
     });
     return {};
   }
@@ -289,7 +289,7 @@ export class DynamicRoutingExampleWorkflow extends BaseWorkflow<{ value: number 
   async showMessagePlaceD(ctx: WorkflowContext, state: DynamicRoutingState): Promise<unknown> {
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: 'Value is less or equal 200, but greater than 100',
+      text: 'Value is less or equal 200, but greater than 100',
     });
     return {};
   }

--- a/registry/examples/dynamic-routing-example-workflow/src/__tests__/dynamic-routing-example.workflow.spec.ts
+++ b/registry/examples/dynamic-routing-example-workflow/src/__tests__/dynamic-routing-example.workflow.spec.ts
@@ -38,11 +38,11 @@ describe('DynamicRoutingExampleWorkflow', () => {
         expect.arrayContaining([
           expect.objectContaining({
             documentName: 'message',
-            content: expect.objectContaining({ role: 'assistant', content: 'Analysing value = 50' }),
+            content: expect.objectContaining({ role: 'assistant', text: 'Analysing value = 50' }),
           }),
           expect.objectContaining({
             documentName: 'message',
-            content: expect.objectContaining({ role: 'assistant', content: 'Value is less or equal 100' }),
+            content: expect.objectContaining({ role: 'assistant', text: 'Value is less or equal 100' }),
           }),
         ]),
       );
@@ -57,11 +57,11 @@ describe('DynamicRoutingExampleWorkflow', () => {
         expect.arrayContaining([
           expect.objectContaining({
             documentName: 'message',
-            content: expect.objectContaining({ role: 'assistant', content: 'Analysing value = 250' }),
+            content: expect.objectContaining({ role: 'assistant', text: 'Analysing value = 250' }),
           }),
           expect.objectContaining({
             documentName: 'message',
-            content: expect.objectContaining({ role: 'assistant', content: 'Value is greater than 200' }),
+            content: expect.objectContaining({ role: 'assistant', text: 'Value is greater than 200' }),
           }),
         ]),
       );
@@ -76,13 +76,13 @@ describe('DynamicRoutingExampleWorkflow', () => {
         expect.arrayContaining([
           expect.objectContaining({
             documentName: 'message',
-            content: expect.objectContaining({ role: 'assistant', content: 'Analysing value = 150' }),
+            content: expect.objectContaining({ role: 'assistant', text: 'Analysing value = 150' }),
           }),
           expect.objectContaining({
             documentName: 'message',
             content: expect.objectContaining({
               role: 'assistant',
-              content: 'Value is less or equal 200, but greater than 100',
+              text: 'Value is less or equal 200, but greater than 100',
             }),
           }),
         ]),

--- a/registry/examples/dynamic-routing-example-workflow/src/dynamic-routing-example.workflow.ts
+++ b/registry/examples/dynamic-routing-example-workflow/src/dynamic-routing-example.workflow.ts
@@ -24,7 +24,7 @@ export class DynamicRoutingExampleWorkflow extends BaseWorkflow<{ value: number 
     const args = ctx.args as { value: number };
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `Analysing value = ${args.value}`,
+      text: `Analysing value = ${args.value}`,
     });
     return { ...state, value: args.value };
   }
@@ -69,7 +69,7 @@ export class DynamicRoutingExampleWorkflow extends BaseWorkflow<{ value: number 
   async showMessagePlaceB(_state: DynamicRoutingState): Promise<unknown> {
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: 'Value is less or equal 100',
+      text: 'Value is less or equal 100',
     });
     return {};
   }
@@ -78,7 +78,7 @@ export class DynamicRoutingExampleWorkflow extends BaseWorkflow<{ value: number 
   async showMessagePlaceC(_state: DynamicRoutingState): Promise<unknown> {
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: 'Value is greater than 200',
+      text: 'Value is greater than 200',
     });
     return {};
   }
@@ -87,7 +87,7 @@ export class DynamicRoutingExampleWorkflow extends BaseWorkflow<{ value: number 
   async showMessagePlaceD(_state: DynamicRoutingState): Promise<unknown> {
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: 'Value is less or equal 200, but greater than 100',
+      text: 'Value is less or equal 200, but greater than 100',
     });
     return {};
   }

--- a/registry/examples/error-retry-example-workflow/src/error-retry.workflow.ts
+++ b/registry/examples/error-retry-example-workflow/src/error-retry.workflow.ts
@@ -38,11 +38,11 @@ export class ErrorRetryWorkflow extends BaseWorkflow<Record<string, unknown>, Er
   async setup(_state: ErrorRetryState): Promise<ErrorRetryState> {
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: '# Error Retry Example\n\nThis workflow tests five retry/error modes in sequence.',
+      text: '# Error Retry Example\n\nThis workflow tests five retry/error modes in sequence.',
     });
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content:
+      text:
         '## Step 1: Auto-retry\n\n' +
         'The next step will fail twice. The framework auto-retries with exponential backoff ' +
         '(1s, then 2s). On the 3rd attempt it succeeds.\n\n' +
@@ -58,7 +58,7 @@ export class ErrorRetryWorkflow extends BaseWorkflow<Record<string, unknown>, Er
     await this.step2Tool.call({ shouldFail: attempt <= 2 });
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `Auto-retry succeeded on attempt ${attempt}.`,
+      text: `Auto-retry succeeded on attempt ${attempt}.`,
     });
     return { ...state, autoRetryAttempts: attempt };
   }
@@ -68,7 +68,7 @@ export class ErrorRetryWorkflow extends BaseWorkflow<Record<string, unknown>, Er
   async step2Instructions(state: ErrorRetryState): Promise<ErrorRetryState> {
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content:
+      text:
         '## Step 2: Manual retry\n\n' +
         'The next step will fail once. The workflow stays at the current place and shows an error.\n\n' +
         '**Click the Retry button next to the error message to re-run the failed step.**',
@@ -83,7 +83,7 @@ export class ErrorRetryWorkflow extends BaseWorkflow<Record<string, unknown>, Er
     await this.step2Tool.call({ shouldFail: attempt <= 1 });
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `Manual retry succeeded on attempt ${attempt}.`,
+      text: `Manual retry succeeded on attempt ${attempt}.`,
     });
     return { ...state, manualRetryAttempts: attempt };
   }
@@ -93,7 +93,7 @@ export class ErrorRetryWorkflow extends BaseWorkflow<Record<string, unknown>, Er
   async step3Instructions(state: ErrorRetryState): Promise<ErrorRetryState> {
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content:
+      text:
         '## Step 3: Custom error place\n\n' +
         'The next step always fails and transitions to a custom error place (`error_custom`).\n\n' +
         '**Click the "Recover" button that appears below to trigger the recovery transition.**',
@@ -112,7 +112,7 @@ export class ErrorRetryWorkflow extends BaseWorkflow<Record<string, unknown>, Er
   async handleCustomError(state: ErrorRetryState): Promise<ErrorRetryState> {
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: 'Recovered via custom error handler!',
+      text: 'Recovered via custom error handler!',
     });
     return state;
   }
@@ -122,7 +122,7 @@ export class ErrorRetryWorkflow extends BaseWorkflow<Record<string, unknown>, Er
   async step4Instructions(state: ErrorRetryState): Promise<ErrorRetryState> {
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content:
+      text:
         '## Step 4: Timeout\n\n' +
         'The next step has a 2-second timeout but takes 5 seconds. It will be killed by the timeout.\n\n' +
         '**Click the Retry button — the second attempt will be fast and succeed.**',
@@ -138,7 +138,7 @@ export class ErrorRetryWorkflow extends BaseWorkflow<Record<string, unknown>, Er
     await this.slowTool.call({ delayMs: attempt <= 1 ? 5000 : 0 });
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `Timeout step succeeded on attempt ${attempt}.`,
+      text: `Timeout step succeeded on attempt ${attempt}.`,
     });
     return { ...state, timeoutAttempts: attempt };
   }
@@ -148,7 +148,7 @@ export class ErrorRetryWorkflow extends BaseWorkflow<Record<string, unknown>, Er
   async step5Instructions(state: ErrorRetryState): Promise<ErrorRetryState> {
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content:
+      text:
         '## Step 5: Hybrid (auto-retry + custom error place)\n\n' +
         'The next step always fails. It auto-retries once, then transitions to `error_hybrid`.\n\n' +
         '**Click the "Recover" button that appears below.**',
@@ -167,7 +167,7 @@ export class ErrorRetryWorkflow extends BaseWorkflow<Record<string, unknown>, Er
   async handleHybridError(state: ErrorRetryState): Promise<ErrorRetryState> {
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: 'Recovered via hybrid error handler!',
+      text: 'Recovered via hybrid error handler!',
     });
     return state;
   }
@@ -176,7 +176,7 @@ export class ErrorRetryWorkflow extends BaseWorkflow<Record<string, unknown>, Er
   async showResult(_state: ErrorRetryState): Promise<unknown> {
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: 'All five retry modes completed successfully!',
+      text: 'All five retry modes completed successfully!',
     });
     return {};
   }

--- a/registry/examples/git-commit-flow-example-workflow/src/git-commit-flow-example.workflow.ts
+++ b/registry/examples/git-commit-flow-example-workflow/src/git-commit-flow-example.workflow.ts
@@ -21,7 +21,7 @@ export class GitCommitFlowExampleWorkflow extends BaseWorkflow {
     const status = await this.gitStatus.call();
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `Status before commit:\n\`\`\`json\n${JSON.stringify(status.data, null, 2)}\n\`\`\``,
+      text: `Status before commit:\n\`\`\`json\n${JSON.stringify(status.data, null, 2)}\n\`\`\``,
     });
     return state;
   }
@@ -43,7 +43,7 @@ export class GitCommitFlowExampleWorkflow extends BaseWorkflow {
     const log = await this.gitLog.call({ limit: 1 });
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `Latest commit:\n\`\`\`json\n${JSON.stringify(log.data, null, 2)}\n\`\`\``,
+      text: `Latest commit:\n\`\`\`json\n${JSON.stringify(log.data, null, 2)}\n\`\`\``,
     });
     return {};
   }

--- a/registry/examples/hitl-ask-user-example-workflow/src/__tests__/hitl-ask-user-example.workflow.spec.ts
+++ b/registry/examples/hitl-ask-user-example-workflow/src/__tests__/hitl-ask-user-example.workflow.spec.ts
@@ -76,7 +76,7 @@ describe('HitlAskUserExampleWorkflow', () => {
           documentName: 'message',
           content: expect.objectContaining({
             role: 'assistant',
-            content: 'Thanks! You answered: Jakob',
+            text: 'Thanks! You answered: Jakob',
           }),
         }),
       ]),

--- a/registry/examples/hitl-ask-user-example-workflow/src/hitl-ask-user-example.workflow.ts
+++ b/registry/examples/hitl-ask-user-example-workflow/src/hitl-ask-user-example.workflow.ts
@@ -33,7 +33,7 @@ export class HitlAskUserExampleWorkflow extends BaseWorkflow {
 
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `Asking user a question (sub-workflow ${result.workflowId})...`,
+      text: `Asking user a question (sub-workflow ${result.workflowId})...`,
     });
 
     await this.documentStore.save(
@@ -71,7 +71,7 @@ export class HitlAskUserExampleWorkflow extends BaseWorkflow {
 
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `Thanks! You answered: ${payload.data.answer}`,
+      text: `Thanks! You answered: ${payload.data.answer}`,
     });
     return {};
   }

--- a/registry/examples/hitl-confirm-example-workflow/src/__tests__/hitl-confirm-example.workflow.spec.ts
+++ b/registry/examples/hitl-confirm-example-workflow/src/__tests__/hitl-confirm-example.workflow.spec.ts
@@ -73,7 +73,7 @@ describe('HitlConfirmExampleWorkflow', () => {
       expect.arrayContaining([
         expect.objectContaining({
           documentName: 'message',
-          content: expect.objectContaining({ content: expect.stringContaining('confirmed') }),
+          content: expect.objectContaining({ text: expect.stringContaining('confirmed') }),
         }),
       ]),
     );
@@ -107,7 +107,7 @@ describe('HitlConfirmExampleWorkflow', () => {
       expect.arrayContaining([
         expect.objectContaining({
           documentName: 'message',
-          content: expect.objectContaining({ content: expect.stringContaining('denied') }),
+          content: expect.objectContaining({ text: expect.stringContaining('denied') }),
         }),
       ]),
     );

--- a/registry/examples/hitl-confirm-example-workflow/src/hitl-confirm-example.workflow.ts
+++ b/registry/examples/hitl-confirm-example-workflow/src/hitl-confirm-example.workflow.ts
@@ -42,7 +42,7 @@ export class HitlConfirmExampleWorkflow extends BaseWorkflow {
 
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `Requesting confirmation (sub-workflow ${result.workflowId})...`,
+      text: `Requesting confirmation (sub-workflow ${result.workflowId})...`,
     });
 
     await this.documentStore.save(
@@ -78,11 +78,11 @@ export class HitlConfirmExampleWorkflow extends BaseWorkflow {
       { id: `link_${payload.workflowId}` },
     );
 
-    const content = payload.data.confirmed ? 'User confirmed — proceeding with deploy.' : 'User denied — aborting.';
+    const text = payload.data.confirmed ? 'User confirmed — proceeding with deploy.' : 'User denied — aborting.';
 
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content,
+      text,
     });
     return {};
   }

--- a/registry/examples/mcp-linear-example-workflow/src/mcp-linear-example.workflow.ts
+++ b/registry/examples/mcp-linear-example-workflow/src/mcp-linear-example.workflow.ts
@@ -57,7 +57,7 @@ export class McpLinearExampleWorkflow extends BaseWorkflow<McpLinearExampleArgs>
 
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `Connected to Linear MCP at ${LINEAR_MCP_URL}.`,
+      text: `Connected to Linear MCP at ${LINEAR_MCP_URL}.`,
     });
     return state;
   }

--- a/registry/examples/module-config-example/src/consumers/default-greeting.workflow.ts
+++ b/registry/examples/module-config-example/src/consumers/default-greeting.workflow.ts
@@ -15,7 +15,7 @@ export class DefaultGreetingWorkflow extends BaseWorkflow {
     const result = await this.greeter.call({ name: 'World' });
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `[Default] ${result.data!.message}`,
+      text: `[Default] ${result.data!.message}`,
     });
     return {};
   }

--- a/registry/examples/module-config-example/src/consumers/french-greeting.workflow.ts
+++ b/registry/examples/module-config-example/src/consumers/french-greeting.workflow.ts
@@ -16,7 +16,7 @@ export class FrenchGreetingWorkflow extends BaseWorkflow {
     const result = await this.greeter.call({ name: 'Monde' });
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `[French] ${result.data!.message}`,
+      text: `[French] ${result.data!.message}`,
     });
     return {};
   }

--- a/registry/examples/module-config-example/src/consumers/german-greeting.workflow.ts
+++ b/registry/examples/module-config-example/src/consumers/german-greeting.workflow.ts
@@ -15,7 +15,7 @@ export class GermanGreetingWorkflow extends BaseWorkflow {
     const result = await this.greeter.call({ name: 'Welt' });
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `[German] ${result.data!.message}`,
+      text: `[German] ${result.data!.message}`,
     });
     return {};
   }

--- a/registry/examples/module-config-example/src/consumers/nested-greeting.workflow.ts
+++ b/registry/examples/module-config-example/src/consumers/nested-greeting.workflow.ts
@@ -16,7 +16,7 @@ export class NestedGreetingWorkflow extends BaseWorkflow {
     const result = await this.greeter.call({ name: 'Mundo' });
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `[Nested/Spanish] ${result.data!.message}`,
+      text: `[Nested/Spanish] ${result.data!.message}`,
     });
     return {};
   }

--- a/registry/examples/remote-file-explorer-example-workflow/src/remote-file-explorer-example.workflow.ts
+++ b/registry/examples/remote-file-explorer-example-workflow/src/remote-file-explorer-example.workflow.ts
@@ -23,7 +23,7 @@ export class RemoteFileExplorerExampleWorkflow extends BaseWorkflow<Record<strin
 
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `Found ${files.length} markdown files:\n${files
+      text: `Found ${files.length} markdown files:\n${files
         .slice(0, 20)
         .map((f) => `- ${f}`)
         .join('\n')}`,
@@ -36,7 +36,7 @@ export class RemoteFileExplorerExampleWorkflow extends BaseWorkflow<Record<strin
     if (!state.firstMatch) {
       await this.documentStore.save(MessageDocument, {
         role: 'assistant',
-        content: 'No markdown files to read.',
+        text: 'No markdown files to read.',
       });
       return {};
     }
@@ -46,7 +46,7 @@ export class RemoteFileExplorerExampleWorkflow extends BaseWorkflow<Record<strin
 
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `# ${state.firstMatch}\n\n${content.slice(0, 500)}`,
+      text: `# ${state.firstMatch}\n\n${content.slice(0, 500)}`,
     });
     return {};
   }

--- a/registry/examples/run-sub-workflow-example/README.md
+++ b/registry/examples/run-sub-workflow-example/README.md
@@ -73,7 +73,7 @@ export class RunSubWorkflowExampleSubWorkflow extends BaseWorkflow {
   async message(): Promise<{ message: string }> {
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: 'Sub workflow completed.',
+      text: 'Sub workflow completed.',
     });
     return { message: 'Hi mom!' };
   }
@@ -126,7 +126,7 @@ async subWorkflowCallback(payload: SubWorkflowCallback) {
   );
   await this.documentStore.save(MessageDocument, {
     role: 'assistant',
-    content: `A message from sub workflow 1: ${payload.data.message}`,
+    text: `A message from sub workflow 1: ${payload.data.message}`,
   });
 }
 ```
@@ -180,7 +180,7 @@ async subWorkflow2Callback(payload: SubWorkflowCallback) {
   );
   await this.documentStore.save(MessageDocument, {
     role: 'assistant',
-    content: `A message from sub workflow 2: ${payload.data.message}`,
+    text: `A message from sub workflow 2: ${payload.data.message}`,
   });
 }
 ```

--- a/registry/examples/run-sub-workflow-example/src/__tests__/run-sub-workflow-example-parent.workflow.spec.ts
+++ b/registry/examples/run-sub-workflow-example/src/__tests__/run-sub-workflow-example-parent.workflow.spec.ts
@@ -111,7 +111,7 @@ describe('RunSubWorkflowExampleParentWorkflow', () => {
             documentName: 'message',
             content: expect.objectContaining({
               role: 'assistant',
-              content: 'A message from sub workflow 1: Hi mom!',
+              text: 'A message from sub workflow 1: Hi mom!',
             }),
           }),
         ]),
@@ -152,7 +152,7 @@ describe('RunSubWorkflowExampleParentWorkflow', () => {
             documentName: 'message',
             content: expect.objectContaining({
               role: 'assistant',
-              content: 'A message from sub workflow 2: Hello from sub workflow 2!',
+              text: 'A message from sub workflow 2: Hello from sub workflow 2!',
             }),
           }),
         ]),

--- a/registry/examples/run-sub-workflow-example/src/run-sub-workflow-example-parent.workflow.ts
+++ b/registry/examples/run-sub-workflow-example/src/run-sub-workflow-example-parent.workflow.ts
@@ -61,7 +61,7 @@ export class RunSubWorkflowExampleParentWorkflow extends BaseWorkflow {
 
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `A message from sub workflow 1: ${payload.data.message}`,
+      text: `A message from sub workflow 1: ${payload.data.message}`,
     });
     return state;
   }
@@ -100,7 +100,7 @@ export class RunSubWorkflowExampleParentWorkflow extends BaseWorkflow {
 
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `A message from sub workflow 2: ${payload.data.message}`,
+      text: `A message from sub workflow 2: ${payload.data.message}`,
     });
     return {};
   }

--- a/registry/examples/run-sub-workflow-example/src/run-sub-workflow-example-sub.workflow.ts
+++ b/registry/examples/run-sub-workflow-example/src/run-sub-workflow-example-sub.workflow.ts
@@ -8,7 +8,7 @@ export class RunSubWorkflowExampleSubWorkflow extends BaseWorkflow {
   async message(_state: Record<string, unknown>): Promise<{ message: string }> {
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: 'Sub workflow completed.',
+      text: 'Sub workflow completed.',
     });
 
     return { message: 'Hi mom!' };

--- a/registry/examples/sandbox-example-workflow/README.md
+++ b/registry/examples/sandbox-example-workflow/README.md
@@ -103,7 +103,7 @@ async initSandbox(state: SandboxExampleState, ctx: RunContext): Promise<SandboxE
 
   await this.documentStore.save(MessageDocument, {
     role: 'assistant',
-    content: `Sandbox initialized successfully. Container ID: ${initResult.data!.containerId}, Docker ID: ${initResult.data!.dockerId}`,
+    text: `Sandbox initialized successfully. Container ID: ${initResult.data!.containerId}, Docker ID: ${initResult.data!.dockerId}`,
   });
   return { ...state, containerId: initResult.data!.containerId };
 }
@@ -121,7 +121,7 @@ async destroySandbox(state: SandboxExampleState): Promise<unknown> {
 
   await this.documentStore.save(MessageDocument, {
     role: 'assistant',
-    content: `Sandbox destroyed. Container ${destroyResult.data!.containerId} removed=${destroyResult.data!.removed}`,
+    text: `Sandbox destroyed. Container ${destroyResult.data!.containerId} removed=${destroyResult.data!.removed}`,
   });
   return {};
 }
@@ -144,7 +144,7 @@ async writeFile(state: SandboxExampleState): Promise<SandboxExampleState> {
 
   await this.documentStore.save(MessageDocument, {
     role: 'assistant',
-    content: `File written: ${writeResult.data!.path} (${writeResult.data!.bytesWritten} bytes)`,
+    text: `File written: ${writeResult.data!.path} (${writeResult.data!.bytesWritten} bytes)`,
   });
   return state;
 }
@@ -159,7 +159,7 @@ async readFile(state: SandboxExampleState): Promise<SandboxExampleState> {
 
   await this.documentStore.save(MessageDocument, {
     role: 'assistant',
-    content: `File read successfully. Content: "${readResult.data!.content}" (encoding: ${readResult.data!.encoding})`,
+    text: `File read successfully. Content: "${readResult.data!.content}" (encoding: ${readResult.data!.encoding})`,
   });
   return { ...state, fileContent: readResult.data!.content };
 }
@@ -174,7 +174,7 @@ async listDir(state: SandboxExampleState): Promise<SandboxExampleState> {
 
   await this.documentStore.save(MessageDocument, {
     role: 'assistant',
-    content: `Directory listing for ${listResult.data!.path}: ${this.formatEntries(listResult.data!.entries)}`,
+    text: `Directory listing for ${listResult.data!.path}: ${this.formatEntries(listResult.data!.entries)}`,
   });
   return { ...state, fileList: listResult.data!.entries };
 }

--- a/registry/examples/sandbox-example-workflow/src/sandbox-example.workflow.ts
+++ b/registry/examples/sandbox-example-workflow/src/sandbox-example.workflow.ts
@@ -117,7 +117,7 @@ export class SandboxExampleWorkflow extends BaseWorkflow<{ outputDir: string }, 
 
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `Sandbox initialized successfully. Container ID: ${initResult.data!.containerId}, Docker ID: ${initResult.data!.dockerId}`,
+      text: `Sandbox initialized successfully. Container ID: ${initResult.data!.containerId}, Docker ID: ${initResult.data!.dockerId}`,
     });
     return { ...state, containerId: initResult.data!.containerId };
   }
@@ -132,7 +132,7 @@ export class SandboxExampleWorkflow extends BaseWorkflow<{ outputDir: string }, 
 
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `Directory created: ${mkdirResult.data!.path} (created: ${mkdirResult.data!.created})`,
+      text: `Directory created: ${mkdirResult.data!.path} (created: ${mkdirResult.data!.created})`,
     });
     return state;
   }
@@ -149,7 +149,7 @@ export class SandboxExampleWorkflow extends BaseWorkflow<{ outputDir: string }, 
 
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `File written: ${writeResult.data!.path} (${writeResult.data!.bytesWritten} bytes)`,
+      text: `File written: ${writeResult.data!.path} (${writeResult.data!.bytesWritten} bytes)`,
     });
     return state;
   }
@@ -164,7 +164,7 @@ export class SandboxExampleWorkflow extends BaseWorkflow<{ outputDir: string }, 
 
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `File read successfully. Content: "${readResult.data!.content}" (encoding: ${readResult.data!.encoding})`,
+      text: `File read successfully. Content: "${readResult.data!.content}" (encoding: ${readResult.data!.encoding})`,
     });
     return { ...state, fileContent: readResult.data!.content };
   }
@@ -179,7 +179,7 @@ export class SandboxExampleWorkflow extends BaseWorkflow<{ outputDir: string }, 
 
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `Directory listing for ${listResult.data!.path}: ${this.formatEntries(listResult.data!.entries)}`,
+      text: `Directory listing for ${listResult.data!.path}: ${this.formatEntries(listResult.data!.entries)}`,
     });
     return { ...state, fileList: listResult.data!.entries };
   }
@@ -193,7 +193,7 @@ export class SandboxExampleWorkflow extends BaseWorkflow<{ outputDir: string }, 
 
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `File existence check: ${existsResult.data!.path} exists=${existsResult.data!.exists}, type=${existsResult.data!.type}`,
+      text: `File existence check: ${existsResult.data!.path} exists=${existsResult.data!.exists}, type=${existsResult.data!.type}`,
     });
     return state;
   }
@@ -207,7 +207,7 @@ export class SandboxExampleWorkflow extends BaseWorkflow<{ outputDir: string }, 
 
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `File info for ${infoResult.data!.name}: type=${infoResult.data!.type}, size=${infoResult.data!.size} bytes, permissions=${infoResult.data!.permissions}, owner=${infoResult.data!.owner}`,
+      text: `File info for ${infoResult.data!.name}: type=${infoResult.data!.type}, size=${infoResult.data!.size} bytes, permissions=${infoResult.data!.permissions}, owner=${infoResult.data!.owner}`,
     });
     return state;
   }
@@ -223,7 +223,7 @@ export class SandboxExampleWorkflow extends BaseWorkflow<{ outputDir: string }, 
 
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `File deleted: ${deleteResult.data!.path} (deleted: ${deleteResult.data!.deleted})`,
+      text: `File deleted: ${deleteResult.data!.path} (deleted: ${deleteResult.data!.deleted})`,
     });
     return state;
   }
@@ -237,7 +237,7 @@ export class SandboxExampleWorkflow extends BaseWorkflow<{ outputDir: string }, 
 
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `Sandbox destroyed. Container ${destroyResult.data!.containerId} removed=${destroyResult.data!.removed}`,
+      text: `Sandbox destroyed. Container ${destroyResult.data!.containerId} removed=${destroyResult.data!.removed}`,
     });
     return {};
   }

--- a/registry/examples/test-ui-documents-example-workflow/src/__tests__/test-ui-documents.workflow.spec.ts
+++ b/registry/examples/test-ui-documents-example-workflow/src/__tests__/test-ui-documents.workflow.spec.ts
@@ -45,7 +45,7 @@ describe('TestUiDocumentsWorkflow', () => {
             documentName: 'message',
             content: {
               role: 'assistant',
-              content: 'This is the default message',
+              text: 'This is the default message',
             },
           }),
         ]),

--- a/registry/examples/test-ui-documents-example-workflow/src/test-ui-documents.workflow.ts
+++ b/registry/examples/test-ui-documents-example-workflow/src/test-ui-documents.workflow.ts
@@ -18,7 +18,7 @@ export class TestUiDocumentsWorkflow extends BaseWorkflow {
     // Message
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: 'This is the default message',
+      text: 'This is the default message',
     });
 
     // Error

--- a/registry/examples/workflow-state-example-workflow/README.md
+++ b/registry/examples/workflow-state-example-workflow/README.md
@@ -87,12 +87,12 @@ State is available as the first parameter in any subsequent transition method:
 async showResults(state: WorkflowStateState): Promise<unknown> {
   await this.documentStore.save(MessageDocument, {
     role: 'assistant',
-    content: `Data from state: ${state.message}`,
+    text: `Data from state: ${state.message}`,
   });
 
   await this.documentStore.save(MessageDocument, {
     role: 'assistant',
-    content: `Use workflow helper method: ${this.messageInUpperCase(state.message!)}`,
+    text: `Use workflow helper method: ${this.messageInUpperCase(state.message!)}`,
   });
   return {};
 }
@@ -132,12 +132,12 @@ export class WorkflowStateWorkflow extends BaseWorkflow<Record<string, unknown>,
   async showResults(state: WorkflowStateState): Promise<unknown> {
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `Data from state: ${state.message}`,
+      text: `Data from state: ${state.message}`,
     });
 
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `Use workflow helper method: ${this.messageInUpperCase(state.message!)}`,
+      text: `Use workflow helper method: ${this.messageInUpperCase(state.message!)}`,
     });
     return {};
   }

--- a/registry/examples/workflow-state-example-workflow/src/__tests__/workflow-state.workflow.spec.ts
+++ b/registry/examples/workflow-state-example-workflow/src/__tests__/workflow-state.workflow.spec.ts
@@ -38,14 +38,14 @@ describe('WorkflowStateWorkflow', () => {
           documentName: 'message',
           content: expect.objectContaining({
             role: 'assistant',
-            content: 'Data from state: Hello :)',
+            text: 'Data from state: Hello :)',
           }),
         }),
         expect.objectContaining({
           documentName: 'message',
           content: expect.objectContaining({
             role: 'assistant',
-            content: 'Use workflow helper method: HELLO :)',
+            text: 'Use workflow helper method: HELLO :)',
           }),
         }),
       ]),

--- a/registry/examples/workflow-state-example-workflow/src/workflow-state.workflow.ts
+++ b/registry/examples/workflow-state-example-workflow/src/workflow-state.workflow.ts
@@ -17,12 +17,12 @@ export class WorkflowStateWorkflow extends BaseWorkflow<Record<string, unknown>,
   async showResults(state: WorkflowStateState): Promise<unknown> {
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `Data from state: ${state.message}`,
+      text: `Data from state: ${state.message}`,
     });
 
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `Use workflow helper method: ${this.messageInUpperCase(state.message!)}`,
+      text: `Use workflow helper method: ${this.messageInUpperCase(state.message!)}`,
     });
     return {};
   }

--- a/registry/features/agent-module/README.md
+++ b/registry/features/agent-module/README.md
@@ -91,7 +91,7 @@ export class MyWorkflow extends BaseWorkflow {
     );
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: payload.data.response,
+      text: payload.data.response,
     });
     return {};
   }

--- a/registry/features/code-agent-module/README.md
+++ b/registry/features/code-agent-module/README.md
@@ -106,7 +106,7 @@ export class MyWorkflow extends BaseWorkflow {
 
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: payload.data.response,
+      text: payload.data.response,
     });
 
     return {};

--- a/registry/features/git-module/README.md
+++ b/registry/features/git-module/README.md
@@ -73,7 +73,7 @@ export class CommitWorkflow extends BaseWorkflow {
     const status = await this.gitStatus.call();
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `Status: ${JSON.stringify(status.data, null, 2)}`,
+      text: `Status: ${JSON.stringify(status.data, null, 2)}`,
     });
     await this.gitAdd.call({ files: ['.'] });
     return state;
@@ -85,7 +85,7 @@ export class CommitWorkflow extends BaseWorkflow {
     const log = await this.gitLog.call({ limit: 1 });
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `Committed: ${JSON.stringify(log.data, null, 2)}`,
+      text: `Committed: ${JSON.stringify(log.data, null, 2)}`,
     });
     return {};
   }

--- a/registry/features/hitl-module/README.md
+++ b/registry/features/hitl-module/README.md
@@ -72,7 +72,7 @@ export class MyWorkflow extends BaseWorkflow {
   async answerReceived(state: Record<string, unknown>, payload: z.infer<typeof AnswerCallback>): Promise<unknown> {
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
-      content: `Hello, ${payload.data.answer}!`,
+      text: `Hello, ${payload.data.answer}!`,
     });
     return {};
   }

--- a/registry/features/llm-provider-module/src/documents/llm-message.document.ts
+++ b/registry/features/llm-provider-module/src/documents/llm-message.document.ts
@@ -1,13 +1,16 @@
 import { z } from 'zod';
-import { Document } from '@loopstack/common';
-import { UIContentBlockSchema, UIMessageSchema } from '@loopstack/contracts/types';
+import { Document, MessageDocument, MessageDocumentSchema } from '@loopstack/common';
+import { UIContentBlockSchema } from '@loopstack/contracts/types';
 import type { LlmContentBlock, LlmStopReason } from '../types/index.js';
 
 // ---------------------------------------------------------------------------
-// Document content schema — loose shape: provide `text`, `blocks`, or both.
+// Document content schema — extends MessageDocumentSchema with a narrowed
+// role union and optional structured content (blocks, stopReason, id).
 // ---------------------------------------------------------------------------
 
-export const LlmMessageDocumentContentSchema = UIMessageSchema.extend({
+export const LlmMessageDocumentContentSchema = z.object({
+  ...MessageDocumentSchema.shape,
+  role: z.enum(['user', 'assistant']),
   id: z.string().optional(),
   blocks: z.array(UIContentBlockSchema).optional(),
   stopReason: z.enum(['end_turn', 'tool_use', 'max_tokens', 'stop_sequence']).optional(),
@@ -24,10 +27,9 @@ export type LlmMessageDocumentContentType = z.infer<typeof LlmMessageDocumentCon
   widget: import.meta.dirname + '/llm-message.document.yaml',
   tags: ['message'],
 })
-export class LlmMessageDocument {
+export class LlmMessageDocument extends MessageDocument {
+  declare role: 'user' | 'assistant';
   id?: string;
-  role: 'user' | 'assistant';
-  text?: string;
   blocks?: LlmContentBlock[];
   stopReason?: LlmStopReason;
 }


### PR DESCRIPTION
- `MessageDocument`: `content: string` → `text?: string`; default tag changed from `['message']` to `['ui-message']` so plain UI bubbles no longer leak into LLM conversation history (`messagesSearchTag` defaults to `'message'`).
- `LlmMessageDocument` now extends `MessageDocument`; exposed fields (`role`, `text`, `blocks`, `stopReason`, `id`) are unchanged.
- Updated `DocumentMessageRenderer`, all registry examples, READMEs, docs, and tests.

To restore the old behaviour and feed a `MessageDocument` into LLM history, save it with explicit `tags: ['message']`.

Closes #189