### PR TITLE
feat(common): auto-render sub-workflows in parent view via show option

### DIFF
--- a/.changeset/subworkflow-show-option.md
+++ b/.changeset/subworkflow-show-option.md
@@ -1,0 +1,29 @@
+---
+'@loopstack/common': minor
+'@loopstack/core': minor
+'@loopstack/loopstack-studio': minor
+'@loopstack/github-integration': patch
+'@loopstack/code-agent': patch
+'@loopstack/hitl': patch
+'@loopstack/secrets-module': patch
+'@loopstack/agent-example-workflow': patch
+'@loopstack/code-agent-example-workflow': patch
+'@loopstack/github-oauth-example': patch
+'@loopstack/google-oauth-example': patch
+'@loopstack/hitl-ask-user-example-workflow': patch
+'@loopstack/hitl-confirm-example-workflow': patch
+'@loopstack/mcp-linear-example-workflow': patch
+'@loopstack/run-sub-workflow-example': patch
+---
+
+Sub-workflow rendering is now controlled by a single `show` option on `RunOptions`, and the orchestrator auto-creates the link card so the parent's view never goes blank.
+
+`BaseWorkflow.run()` accepts `show?: 'inline' | 'link' | 'hidden'` (default `'inline'`) and `label?: string`. The orchestrator writes the matching `LinkDocument` into the parent's stream from `WorkflowOrchestrationService.queue()` while still inside the parent's `ExecutionScope`:
+
+- `'inline'` — `embed: true, expanded: true` (iframe in the parent's view). Right for HITL/OAuth/agents.
+- `'link'` — `embed: false` (status card opens in a separate window). Right for autonomous children.
+- `'hidden'` — no save. Right for fan-out / background work.
+
+The `status` field is removed from `LinkDocumentSchema`. The Studio `LinkCard` reads live status from `useChildWorkflows(parentId)` (already SSE-invalidated) and maps `WorkflowState` to its colored badge — there is no longer any denormalized status to keep in sync.
+
+All registry features, examples, and sandbox call sites drop their manual `documentStore.save(LinkDocument, …)` pairs around `subWorkflow.run()` and pass `show` + `label` on the `.run()` call instead.

--- a/docs/build/fundamentals/documents.md
+++ b/docs/build/fundamentals/documents.md
@@ -132,14 +132,14 @@ const all = this.documentStore.findAllDocuments();
 
 These are available without creating custom documents:
 
-| Document             | Source                           | Key Fields                                           |
-| -------------------- | -------------------------------- | ---------------------------------------------------- |
-| `LlmMessageDocument` | `@loopstack/llm-provider-module` | `role`, `text`, `blocks`                             |
-| `LinkDocument`       | `@loopstack/common`              | `label`, `workflowId`, `status`, `embed`, `expanded` |
-| `MessageDocument`    | `@loopstack/common`              | `role`, `text`                                       |
-| `MarkdownDocument`   | `@loopstack/common`              | `markdown`                                           |
-| `PlainDocument`      | `@loopstack/common`              | `text`                                               |
-| `ErrorDocument`      | `@loopstack/common`              | `error`                                              |
+| Document             | Source                           | Key Fields                                 |
+| -------------------- | -------------------------------- | ------------------------------------------ |
+| `LlmMessageDocument` | `@loopstack/llm-provider-module` | `role`, `text`, `blocks`                   |
+| `LinkDocument`       | `@loopstack/common`              | `label`, `workflowId`, `embed`, `expanded` |
+| `MessageDocument`    | `@loopstack/common`              | `role`, `text`                             |
+| `MarkdownDocument`   | `@loopstack/common`              | `markdown`                                 |
+| `PlainDocument`      | `@loopstack/common`              | `text`                                     |
+| `ErrorDocument`      | `@loopstack/common`              | `error`                                    |
 
 ### Choosing the right built-in type
 
@@ -147,7 +147,7 @@ These are available without creating custom documents:
 - **`MessageDocument`** — plain `{ role, text }` UI bubbles for non-LLM flows (status updates, narrative output, logging a `system` note). Tagged `'ui-message'` — **not** collected into LLM history. Use this when you want a chat-style message in Studio without polluting the LLM's context.
 - **`MarkdownDocument`** — formatted prose, headings, lists, links. Use when you want Studio to render rich text.
 - **`PlainDocument`** — unformatted text output: raw command output, log dumps, plain blob. Use when Markdown rendering would interpret characters you want shown literally.
-- **`LinkDocument`** — links to other workflow runs (sub-workflows, related runs). Studio renders these as inline cards with status indicators.
+- **`LinkDocument`** — links to other workflow runs (sub-workflows, related runs). Studio renders these as cards with a live status indicator derived from the linked workflow's state. The orchestrator saves one automatically when you call `subWorkflow.run()` (see [Sub-Workflows](../patterns/sub-workflows.md)); save manually only if you need a link card outside the standard sub-workflow flow.
 - **`ErrorDocument`** — engine-managed; do not construct manually. Written automatically when a transition fails (see [Workflow Engine — ErrorDocument](../../learn/workflow-engine.md#errordocument)).
 
 ```typescript

--- a/docs/build/fundamentals/tools.md
+++ b/docs/build/fundamentals/tools.md
@@ -160,20 +160,21 @@ async complete(result: Record<string, unknown>): Promise<ToolResult> {
 }
 ```
 
-Override it when you need to post-process: transform the payload, update link documents, validate, or short-circuit. The HITL pattern uses this — `AskForApprovalTool.handle()` saves a "Waiting…" link document and returns `pending`; `complete()` rewrites that document with the user's decision and returns the typed answer.
+Override it when you need to post-process: transform the payload, validate, or short-circuit. The HITL pattern uses this — `AskForApprovalTool.handle()` launches the sub-workflow with `show: 'inline'` so its UI appears in the parent's run view, and returns `pending`; `complete()` returns the user's decision as the typed answer.
 
 ```typescript
 @Tool({ name: 'ask_for_approval', description: 'Ask the user to approve.', /* … */ })
 export class AskForApprovalTool extends BaseTool</* … */> {
   protected async handle(/* … */) {
-    const { workflowId } = await this.confirmWorkflow.run(args, { callback: { transition: 'onConfirm' } });
-    // … save a "pending" LinkDocument
+    const { workflowId } = await this.confirmWorkflow.run(
+      args,
+      { callback: { transition: 'onConfirm' }, show: 'inline', label: 'Waiting for approval...' },
+    );
     return { data: { workflowId }, pending: { workflowId } };
   }
 
   async complete(result: Record<string, unknown>): Promise<ToolResult<AskForApprovalResult>> {
     const { workflowId, data } = result as { workflowId: string; data: { confirmed: boolean } };
-    // … rewrite the LinkDocument with the final state
     return { data: { approved: data.confirmed, workflowId } };
   }
 }

--- a/docs/build/integrations/oauth.md
+++ b/docs/build/integrations/oauth.md
@@ -64,7 +64,7 @@ The simplest approach: launch the built-in `OAuthWorkflow` when authentication i
 ```typescript
 import { BaseWorkflow, CallbackSchema, Guard, Transition, Workflow } from '@loopstack/common';
 import type { RunContext } from '@loopstack/common';
-import { LinkDocument, MarkdownDocument } from '@loopstack/common';
+import { MarkdownDocument } from '@loopstack/common';
 import { OAuthWorkflow } from '@loopstack/oauth-module';
 
 interface CalendarState {
@@ -98,20 +98,9 @@ export class CalendarWorkflow extends BaseWorkflow<{ calendarId: string }, Calen
   @Transition({ from: 'calendar_fetched', to: 'awaiting_auth', priority: 10 })
   @Guard('needsAuth')
   async authRequired(state: CalendarState): Promise<CalendarState> {
-    const result = await this.oAuth.run(
+    await this.oAuth.run(
       { provider: 'google', scopes: ['https://www.googleapis.com/auth/calendar.readonly'] },
-      { callback: { transition: 'authCompleted' } },
-    );
-
-    await this.documentStore.save(
-      LinkDocument,
-      {
-        label: 'Google authentication required',
-        workflowId: result.workflowId,
-        embed: true,
-        expanded: true,
-      },
-      { id: `link_${result.workflowId}` },
+      { callback: { transition: 'authCompleted' }, show: 'inline', label: 'Google authentication required' },
     );
     return state;
   }
@@ -122,16 +111,7 @@ export class CalendarWorkflow extends BaseWorkflow<{ calendarId: string }, Calen
 
   // After auth -> retry from start
   @Transition({ from: 'awaiting_auth', to: 'start', wait: true, schema: CallbackSchema })
-  async authCompleted(state: CalendarState, payload: { workflowId: string }): Promise<CalendarState> {
-    await this.documentStore.save(
-      LinkDocument,
-      {
-        status: 'success',
-        label: 'Google authentication completed',
-        workflowId: payload.workflowId,
-      },
-      { id: `link_${payload.workflowId}` },
-    );
+  async authCompleted(state: CalendarState, _payload: { workflowId: string }): Promise<CalendarState> {
     return state;
   }
 

--- a/docs/build/patterns/sub-workflows.md
+++ b/docs/build/patterns/sub-workflows.md
@@ -1,6 +1,6 @@
 ---
 title: Sub-Workflows
-description: Running workflows inside other workflows via .run(), callback transitions, passing arguments to child workflows, and receiving sub-workflow results.
+description: Running workflows inside other workflows via .run(), the show option ('inline' | 'link' | 'hidden') for parent-view rendering, callback transitions, passing arguments to child workflows, and receiving sub-workflow results.
 ---
 
 # Sub-Workflows
@@ -22,19 +22,44 @@ constructor(private readonly subWorkflow: SubWorkflow) {
 ```typescript
 @Transition({ to: 'sub_started' })
 async start(state: MyState): Promise<MyState> {
-  const result: QueueResult = await this.subWorkflow.run(
-    { prompt: 'Hello' },                         // Args passed to the sub-workflow
+  await this.subWorkflow.run(
+    { prompt: 'Hello' },                          // Args passed to the sub-workflow
     { callback: { transition: 'onSubComplete' } }, // Method to call when done
   );
-
-  // Track with a link document
-  await this.documentStore.save(LinkDocument, {
-    label: 'Running sub-workflow...',
-    workflowId: result.workflowId,
-  }, { id: `link_${result.workflowId}` });
   return state;
 }
 ```
+
+The parent's run view automatically renders the child sub-workflow inline by default — there is no extra `documentStore.save(LinkDocument, …)` step.
+
+## Controlling How the Child Appears: `show`
+
+The `show` option on `RunOptions` controls how the child sub-workflow is rendered inside the parent's run view:
+
+| `show`                 | What the parent sees                                                                                           | Use for                                                            |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| `'inline'` _(default)_ | The child is embedded as an inline iframe; the user can interact with it in place.                             | HITL prompts, OAuth flows, agents whose progress you want visible. |
+| `'link'`               | A status link card with the child's label and live status — opens the child in a separate window when clicked. | Long-running autonomous children the parent just tracks.           |
+| `'hidden'`             | Nothing is shown.                                                                                              | Background fan-out where surfacing each child would be noise.      |
+
+```typescript
+await this.askUser.run(args, {
+  callback: { transition: 'answered' },
+  show: 'inline', // (default) embed the child UI in the parent's view
+  label: 'Waiting for user answer', // optional — defaults to the child workflow's name
+});
+
+await this.longJob.run(args, {
+  callback: { transition: 'done' },
+  show: 'link', // status card, opens child in a separate window
+});
+
+await this.background.run(args, {
+  show: 'hidden', // no card at all
+});
+```
+
+The link card's status is read live from the child workflow's actual state — it transitions from pending to success or failure automatically as the child runs.
 
 ## Receiving the Callback
 
@@ -51,14 +76,10 @@ const SubWorkflowCallbackSchema = CallbackSchema.extend({
   wait: true,
   schema: SubWorkflowCallbackSchema,
 })
-async onSubComplete(state: MyState, payload: { workflowId: string; status: string; data: { message: string } }): Promise<MyState> {
-  // Update the link document
-  await this.documentStore.save(LinkDocument, {
-    label: 'Sub-Workflow',
-    status: 'success',
-    workflowId: payload.workflowId,
-  }, { id: `link_${payload.workflowId}` });
-
+async onSubComplete(
+  state: MyState,
+  payload: { workflowId: string; status: string; data: { message: string } },
+): Promise<MyState> {
   await this.documentStore.save(MessageDocument, {
     role: 'assistant',
     text: `Sub-workflow said: ${payload.data.message}`,
@@ -92,15 +113,9 @@ export class ParentWorkflow extends BaseWorkflow {
 
   @Transition({ to: 'sub_started' })
   async runWorkflow(state: Record<string, unknown>): Promise<Record<string, unknown>> {
-    const result: QueueResult = await this.subWorkflow.run({}, { callback: { transition: 'subWorkflowCallback' } });
-
-    await this.documentStore.save(
-      LinkDocument,
-      {
-        label: 'Executing Sub-Workflow...',
-        workflowId: result.workflowId,
-      },
-      { id: `link_${result.workflowId}` },
+    await this.subWorkflow.run(
+      {},
+      { callback: { transition: 'subWorkflowCallback' }, show: 'link', label: 'Sub-Workflow' },
     );
     return state;
   }
@@ -115,16 +130,6 @@ export class ParentWorkflow extends BaseWorkflow {
     state: Record<string, unknown>,
     payload: { workflowId: string; status: string; data: { message: string } },
   ): Promise<unknown> {
-    await this.documentStore.save(
-      LinkDocument,
-      {
-        label: 'Sub-Workflow',
-        status: 'success',
-        workflowId: payload.workflowId,
-      },
-      { id: `link_${payload.workflowId}` },
-    );
-
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
       text: `Message from sub-workflow: ${payload.data.message}`,
@@ -168,12 +173,9 @@ export class RunTestsTask extends BaseTool {
     ctx: RunContext,
     options?: ToolCallOptions,
   ): Promise<ToolResult> {
-    const result = await this.testRunner.run({ testDirectory: args.testDirectory }, { callback: options?.callback });
-
-    await this.documentStore.save(
-      LinkDocument,
-      { status: 'pending', label: 'Running tests...', workflowId: result.workflowId, embed: true },
-      { id: `test_link_${result.workflowId}` },
+    const result = await this.testRunner.run(
+      { testDirectory: args.testDirectory },
+      { callback: options?.callback, show: 'inline', label: 'Running tests...' },
     );
 
     return {
@@ -183,14 +185,7 @@ export class RunTestsTask extends BaseTool {
   }
 
   async complete(result: Record<string, unknown>): Promise<ToolResult> {
-    const data = result as { workflowId?: string; data?: { passed: boolean; output: string } };
-
-    await this.documentStore.save(
-      LinkDocument,
-      { status: data.data?.passed ? 'success' : 'failure', label: 'Tests complete', workflowId: data.workflowId! },
-      { id: `test_link_${data.workflowId}` },
-    );
-
+    const data = result as { data?: { passed: boolean; output: string } };
     return { data: data.data ?? result };
   }
 }
@@ -200,8 +195,8 @@ Key parts:
 
 - **`pending: { workflowId }`** tells the framework this tool is async — the parent workflow waits for a callback
 - **`callback: options?.callback`** passes the parent's callback config to the sub-workflow
-- **`complete()`** is called when the sub-workflow finishes — transform results and update UI documents here
-- **`LinkDocument`** gives visual feedback while the sub-workflow runs
+- **`show`** decides how the child appears in the parent's run view (`'inline'` by default)
+- **`complete()`** is called when the sub-workflow finishes — transform results and return the tool's final value here
 
 ## Nested Agents
 
@@ -209,5 +204,5 @@ The sub-workflow can be an `AgentWorkflow` itself, enabling multi-agent architec
 
 ## Registry References
 
-- [run-sub-workflow-example](https://loopstack.ai/registry/loopstack-run-sub-workflow-example) — Parent workflow calling a sub-workflow with callbacks, LinkDocument tracking, and output passing
+- [run-sub-workflow-example](https://loopstack.ai/registry/loopstack-run-sub-workflow-example) — Parent workflow calling a sub-workflow with callbacks and output passing
 - [@loopstack/code-agent](https://loopstack.ai/registry/loopstack-code-agent) — ExploreTask wrapping AgentWorkflow as a task tool

--- a/docs/learn/capabilities.md
+++ b/docs/learn/capabilities.md
@@ -50,14 +50,14 @@ Quick reference for what Loopstack can do. Each entry links to the relevant buil
 
 ## UI & Studio
 
-| Capability                 | Description                                                |
-| -------------------------- | ---------------------------------------------------------- |
-| Visual workflow monitoring | Watch workflow execution in real-time                      |
-| Chat interface             | `prompt-input` widget for conversational UIs               |
-| Form widgets               | Text, textarea, select, slider, code-view, radio, checkbox |
-| Document actions           | Buttons that trigger workflow transitions                  |
-| Conditional widgets        | `enabledWhen` shows/hides UI based on workflow state       |
-| Sub-workflow embedding     | LinkDocument displays sub-workflow progress inline         |
+| Capability                 | Description                                                                                                  |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| Visual workflow monitoring | Watch workflow execution in real-time                                                                        |
+| Chat interface             | `prompt-input` widget for conversational UIs                                                                 |
+| Form widgets               | Text, textarea, select, slider, code-view, radio, checkbox                                                   |
+| Document actions           | Buttons that trigger workflow transitions                                                                    |
+| Conditional widgets        | `enabledWhen` shows/hides UI based on workflow state                                                         |
+| Sub-workflow embedding     | `.run()` auto-renders child workflows inline in the parent's view via `show: 'inline' \| 'link' \| 'hidden'` |
 
 ## Extensibility
 

--- a/docs/learn/document-store.md
+++ b/docs/learn/document-store.md
@@ -146,14 +146,14 @@ await this.documentStore.save(LlmMessageDocument, { role: 'user', text: systemPr
 
 You don't always need to create custom documents. The built-in types cover the most common cases:
 
-| Document             | Source                           | Use case                                                                                                   |
-| -------------------- | -------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| `LlmMessageDocument` | `@loopstack/llm-provider-module` | Chat messages — user and assistant turns, tool calls, tool results. Collected into LLM history by default. |
-| `MessageDocument`    | `@loopstack/common`              | UI-only role/text bubbles (status updates, narrative). Not collected into LLM history.                     |
-| `MarkdownDocument`   | `@loopstack/common`              | Rich text output rendered as formatted markdown                                                            |
-| `PlainDocument`      | `@loopstack/common`              | Plain text output                                                                                          |
-| `LinkDocument`       | `@loopstack/common`              | Links to sub-workflow runs, with embed and status support                                                  |
-| `ErrorDocument`      | `@loopstack/common`              | Error messages, automatically saved on transition failure                                                  |
+| Document             | Source                           | Use case                                                                                                                                                             |
+| -------------------- | -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `LlmMessageDocument` | `@loopstack/llm-provider-module` | Chat messages — user and assistant turns, tool calls, tool results. Collected into LLM history by default.                                                           |
+| `MessageDocument`    | `@loopstack/common`              | UI-only role/text bubbles (status updates, narrative). Not collected into LLM history.                                                                               |
+| `MarkdownDocument`   | `@loopstack/common`              | Rich text output rendered as formatted markdown                                                                                                                      |
+| `PlainDocument`      | `@loopstack/common`              | Plain text output                                                                                                                                                    |
+| `LinkDocument`       | `@loopstack/common`              | Status card / inline embed for sub-workflow runs. Auto-saved by `subWorkflow.run()` based on the `show` option; live status derived from the child workflow's state. |
+| `ErrorDocument`      | `@loopstack/common`              | Error messages, automatically saved on transition failure                                                                                                            |
 
 Custom documents are for when you need structured forms, interactive fields, or action buttons — see the [Creating Documents](../build/fundamentals/documents.md) guide.
 

--- a/docs/skills/create-custom-document.md
+++ b/docs/skills/create-custom-document.md
@@ -113,14 +113,14 @@ const all = this.documentStore.findAllDocuments();
 
 Don't redefine these — import and save:
 
-| Document             | Source                           | Key fields                                           |
-| -------------------- | -------------------------------- | ---------------------------------------------------- |
-| `LlmMessageDocument` | `@loopstack/llm-provider-module` | `role`, `text`, `blocks`                             |
-| `LinkDocument`       | `@loopstack/common`              | `label`, `workflowId`, `status`, `embed`, `expanded` |
-| `MessageDocument`    | `@loopstack/common`              | `role`, `text`                                       |
-| `MarkdownDocument`   | `@loopstack/common`              | `markdown`                                           |
-| `PlainDocument`      | `@loopstack/common`              | `text`                                               |
-| `ErrorDocument`      | `@loopstack/common`              | `error`                                              |
+| Document             | Source                           | Key fields                                 |
+| -------------------- | -------------------------------- | ------------------------------------------ |
+| `LlmMessageDocument` | `@loopstack/llm-provider-module` | `role`, `text`, `blocks`                   |
+| `LinkDocument`       | `@loopstack/common`              | `label`, `workflowId`, `embed`, `expanded` |
+| `MessageDocument`    | `@loopstack/common`              | `role`, `text`                             |
+| `MarkdownDocument`   | `@loopstack/common`              | `markdown`                                 |
+| `PlainDocument`      | `@loopstack/common`              | `text`                                     |
+| `ErrorDocument`      | `@loopstack/common`              | `error`                                    |
 
 ```typescript
 import { MarkdownDocument } from '@loopstack/common';

--- a/docs/skills/create-custom-workflow.md
+++ b/docs/skills/create-custom-workflow.md
@@ -208,7 +208,6 @@ export class MyWorkflow extends BaseWorkflow<MyArgs, MyState> {
 Documents are referenced by class — no injection needed. Use `this.documentStore.save()` to create/update documents. `documentStore` is auto-injected on `BaseWorkflow`.
 
 ```typescript
-import { LinkDocument } from '@loopstack/common';
 import { LlmMessageDocument } from '@loopstack/llm-provider-module';
 
 // Save a new document
@@ -338,23 +337,17 @@ Best practice: add a `schema` to validate the callback payload and receive it as
 
 ## Sub-Workflows
 
-Inject sub-workflows via the constructor and use `.run()` to execute them asynchronously.
+Inject sub-workflows via the constructor and use `.run()` to execute them asynchronously. The orchestrator automatically renders the child in the parent's run view based on the `show` option (default `'inline'`).
 
 ```typescript
 constructor(private readonly subWorkflow: SubWorkflow) { super(); }
 
 @Transition({ to: 'sub_started' })
 async start(state: MyState): Promise<MyState> {
-  const result: QueueResult = await this.subWorkflow.run(
-    { prompt: 'Hello' },                                    // args
-    { callback: { transition: 'onSubComplete' } },  // options
+  await this.subWorkflow.run(
+    { prompt: 'Hello' },                                                       // args
+    { callback: { transition: 'onSubComplete' }, show: 'inline', label: 'Running sub-workflow...' },
   );
-
-  // Track the sub-workflow with a link document
-  await this.documentStore.save(LinkDocument, {
-    label: 'Running sub-workflow...',
-    workflowId: result.workflowId,
-  }, { id: `link_${result.workflowId}` });
   return state;
 }
 
@@ -369,6 +362,8 @@ async onSubComplete(state: MyState, payload: { workflowId: string; status: strin
   return state;
 }
 ```
+
+`show` accepts `'inline'` (default — embed as iframe), `'link'` (status link card opening in a separate window), or `'hidden'` (no card). See [Sub-Workflows](../build/patterns/sub-workflows.md) for the full reference.
 
 ## Workflow Output
 

--- a/docs/skills/use-core-tools.md
+++ b/docs/skills/use-core-tools.md
@@ -27,9 +27,9 @@ constructor(private readonly subWorkflow: SubWorkflow) { super(); }
 const result: QueueResult = await this.subWorkflow.run(
   { prompt: 'Hello' }, // args passed to the sub-workflow
   {
-    callback: {
-      transition: 'onSubComplete', // method name of the wait transition
-    },
+    callback: { transition: 'onSubComplete' }, // method name of the wait transition
+    show: 'inline', // 'inline' (default) | 'link' | 'hidden' — how the child appears in the parent's view
+    label: 'Running sub-workflow', // optional override (defaults to the child workflow's name)
   },
 );
 // result.workflowId — the ID of the spawned sub-workflow
@@ -71,56 +71,32 @@ async finish(state: SubState): Promise<{ message: string }> {
 }
 ```
 
-### Tracking with LinkDocument
+### Rendering in the Parent's View
 
-Use `LinkDocument` to show a clickable link to the sub-workflow in the UI:
+The `show` option on `.run()` controls how the child appears inside the parent's run view:
 
-```typescript
-import { LinkDocument } from '@loopstack/common';
+- `'inline'` _(default)_ — child is embedded as an inline iframe. Best for HITL / OAuth / interactive children.
+- `'link'` — status link card, opens the child in a separate window. Best for autonomous children the parent just tracks.
+- `'hidden'` — no card at all. Best for background fan-out.
 
-await this.documentStore.save(
-  LinkDocument,
-  {
-    label: 'Running sub-workflow...',
-    workflowId: result.workflowId,
-  },
-  { id: `link_${result.workflowId}` },
-);
-
-// Update after completion
-await this.documentStore.save(
-  LinkDocument,
-  {
-    label: 'Sub-Workflow',
-    status: 'success',
-    workflowId: payload.workflowId,
-  },
-  { id: `link_${payload.workflowId}` },
-);
-```
+The orchestrator auto-creates the corresponding `LinkDocument` for `'inline'` and `'link'`; the card's status is derived live from the child workflow's actual state — no manual updates needed.
 
 ## Built-in Document Types
 
 These document types are available from `@loopstack/common` without additional imports:
 
-| Document           | Description                     | Key Fields                                           |
-| ------------------ | ------------------------------- | ---------------------------------------------------- |
-| `MessageDocument`  | UI-only chat message            | `role`, `text`                                       |
-| `MarkdownDocument` | Rendered markdown               | `markdown`                                           |
-| `PlainDocument`    | Plain text                      | `text`                                               |
-| `ErrorDocument`    | Error message (red styling)     | `error`                                              |
-| `LinkDocument`     | Clickable link to sub-workflows | `label`, `workflowId`, `status`, `embed`, `expanded` |
+| Document           | Description                                                        | Key Fields                                 |
+| ------------------ | ------------------------------------------------------------------ | ------------------------------------------ |
+| `MessageDocument`  | UI-only chat message                                               | `role`, `text`                             |
+| `MarkdownDocument` | Rendered markdown                                                  | `markdown`                                 |
+| `PlainDocument`    | Plain text                                                         | `text`                                     |
+| `ErrorDocument`    | Error message (red styling)                                        | `error`                                    |
+| `LinkDocument`     | Status card / iframe link to sub-workflows (auto-saved by `run()`) | `label`, `workflowId`, `embed`, `expanded` |
 
 ### Usage
 
 ```typescript
-import { LinkDocument, MessageDocument } from '@loopstack/common';
-
-// Save any built-in document
-await this.documentStore.save(LinkDocument, {
-  label: 'View Details',
-  workflowId: result.workflowId,
-});
+import { MessageDocument } from '@loopstack/common';
 
 await this.documentStore.save(MessageDocument, {
   role: 'assistant',

--- a/frontend/studio/src/features/documents/DocumentRenderer.tsx
+++ b/frontend/studio/src/features/documents/DocumentRenderer.tsx
@@ -63,7 +63,7 @@ const coreRendererRegistry = new Map<string, WidgetRenderer>([
   ['error', ({ document }) => <ErrorMessageRenderer document={document} />],
   ['plain', ({ document }) => <PlainMessageRenderer document={document} />],
   ['markdown', ({ document }) => <MarkdownMessageRenderer document={document} />],
-  ['link', ({ document }) => <LinkMessageRenderer document={document} />],
+  ['link', ({ workflow, document }) => <LinkMessageRenderer workflow={workflow} document={document} />],
   [
     'oauth-prompt',
     ({ parentWorkflow, workflow, document, isActive }) => (

--- a/frontend/studio/src/features/documents/renderers/LinkMessageRenderer.tsx
+++ b/frontend/studio/src/features/documents/renderers/LinkMessageRenderer.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
+import type { WorkflowFullInterface } from '@loopstack/contracts/api';
+import { WorkflowState } from '@loopstack/contracts/enums';
 import type { DocumentItemInterface } from '@loopstack/contracts/types';
 import LinkCard, { type LinkCardStatus } from '@/components/loopstack-elements/link.tsx';
+import { useChildWorkflows } from '@/hooks/useWorkflows.ts';
 
 type LinkMessageContentType = {
-  status?: LinkCardStatus;
   label?: string;
   workflowId?: string;
   embed?: boolean;
@@ -11,12 +13,29 @@ type LinkMessageContentType = {
 };
 
 interface LinkMessageRendererProps {
+  workflow: WorkflowFullInterface;
   document: Omit<DocumentItemInterface, 'content'> & { content: LinkMessageContentType };
 }
 
-const LinkMessageRenderer: React.FC<LinkMessageRendererProps> = ({ document }) => {
-  const { status, label, workflowId, embed, expanded } = document.content;
+function mapWorkflowStateToStatus(state: WorkflowState | undefined): LinkCardStatus {
+  switch (state) {
+    case WorkflowState.Completed:
+      return 'success';
+    case WorkflowState.Failed:
+    case WorkflowState.Canceled:
+      return 'failure';
+    default:
+      return 'pending';
+  }
+}
+
+const LinkMessageRenderer: React.FC<LinkMessageRendererProps> = ({ workflow, document }) => {
+  const { label, workflowId, embed, expanded } = document.content;
   const href = workflowId ? `/workflows/${workflowId}` : undefined;
+
+  const childWorkflows = useChildWorkflows(workflow.id);
+  const child = workflowId ? childWorkflows.data?.find((c) => c.id === workflowId) : undefined;
+  const status = mapWorkflowStateToStatus(child?.status as WorkflowState | undefined);
 
   return <LinkCard href={href} label={label} status={status} embed={embed} defaultExpanded={expanded} />;
 };

--- a/packages/common/src/base/base-workflow.ts
+++ b/packages/common/src/base/base-workflow.ts
@@ -5,8 +5,23 @@ import type { WorkflowOrchestrator } from '../interfaces/workflow-orchestrator.i
 import { DOCUMENT_STORE, TEMPLATE_RENDERER, WORKFLOW_ORCHESTRATOR } from '../tokens.js';
 import type { TemplateRenderFn } from './workflow-templates.js';
 
+/**
+ * How a sub-workflow appears inside its parent's run view.
+ *
+ * - `'inline'` *(default)* — the child is rendered inline as an embedded iframe.
+ *   Use for interactive children (HITL, OAuth flows).
+ * - `'link'` — the child appears as a status link card in the parent's stream;
+ *   clicking opens it in a separate window. Use for autonomous children the
+ *   user only needs to track.
+ * - `'hidden'` — no UI is added to the parent's stream. Use for background
+ *   fan-out where surfacing each child would be noise.
+ */
+export type SubWorkflowShow = 'inline' | 'link' | 'hidden';
+
 export interface RunOptions {
   callback?: { transition: string; metadata?: Record<string, unknown> };
+  show?: SubWorkflowShow;
+  label?: string;
 }
 
 /**

--- a/packages/common/src/documents/link-document.ts
+++ b/packages/common/src/documents/link-document.ts
@@ -3,7 +3,6 @@ import { Document } from '../decorators/block.decorator.js';
 
 export const LinkDocumentSchema = z
   .object({
-    status: z.enum(['pending', 'success', 'failure']).optional(),
     label: z.string().optional(),
     workflowId: z.string().optional(),
     embed: z.boolean().optional(),
@@ -18,7 +17,6 @@ export type LinkDocumentContent = z.infer<typeof LinkDocumentSchema>;
   widget: import.meta.dirname + '/link-document.yaml',
 })
 export class LinkDocument {
-  status?: 'pending' | 'success' | 'failure';
   label?: string;
   workflowId?: string;
   embed?: boolean;

--- a/packages/core/src/workflow-processor/services/workflow-orchestration.service.ts
+++ b/packages/core/src/workflow-processor/services/workflow-orchestration.service.ts
@@ -1,9 +1,11 @@
 import { Injectable, Logger, Type } from '@nestjs/common';
 import { randomUUID } from 'node:crypto';
 import {
+  LinkDocument,
   QueueResult,
   ResumeOptions,
   RunOptions,
+  SubWorkflowShow,
   WorkflowEntity,
   WorkflowOrchestrator,
   WorkflowState,
@@ -13,6 +15,7 @@ import { WorkflowService } from '../../persistence/services/workflow.service.js'
 import { TaskSchedulerService } from '../../scheduler/services/task-scheduler.service.js';
 import { ExecutionScope } from '../utils/index.js';
 import { CreateWorkflowService } from './create-workflow.service.js';
+import { DocumentStore } from './document-store.service.js';
 import { WorkflowRegistryService } from './workflow-registry.service.js';
 
 /**
@@ -33,6 +36,7 @@ export class WorkflowOrchestrationService implements WorkflowOrchestrator {
     private readonly taskSchedulerService: TaskSchedulerService,
     private readonly workflowService: WorkflowService,
     private readonly workflowRegistryService: WorkflowRegistryService,
+    private readonly documentStore: DocumentStore,
   ) {}
 
   async queue(workflowClass: Type, args?: Record<string, unknown>, options?: RunOptions): Promise<QueueResult> {
@@ -73,9 +77,32 @@ export class WorkflowOrchestrationService implements WorkflowOrchestrator {
       },
     } satisfies ScheduledTask);
 
+    await this.persistSubWorkflowLink(workflowEntity.id, workflowName, options);
+
     return {
       workflowId: workflowEntity.id,
     };
+  }
+
+  private async persistSubWorkflowLink(
+    childWorkflowId: string,
+    workflowName: string,
+    options: RunOptions | undefined,
+  ): Promise<void> {
+    const show: SubWorkflowShow = options?.show ?? 'inline';
+    if (show === 'hidden') return;
+
+    const label = options?.label ?? workflowName;
+    await this.documentStore.save(
+      LinkDocument,
+      {
+        label,
+        workflowId: childWorkflowId,
+        embed: show === 'inline',
+        expanded: show === 'inline',
+      },
+      { id: `link_${childWorkflowId}` },
+    );
   }
 
   async resume(workflowId: string, payload: Record<string, unknown>, options: ResumeOptions): Promise<void> {

--- a/registry/examples/agent-example-workflow/README.md
+++ b/registry/examples/agent-example-workflow/README.md
@@ -10,7 +10,7 @@ Demonstrates how to launch `AgentWorkflow` from [`@loopstack/agent`](https://loo
 ## By using this example you'll get...
 
 - A parent workflow that queues `AgentWorkflow` via `WORKFLOW_ORCHESTRATOR`
-- A `LinkDocument` that embeds the running child workflow
+- The child agent rendered inline in the parent's view via `show: 'inline'`
 - A callback transition that stores the final agent response as a `MessageDocument`
 
 ## Installation
@@ -39,10 +39,9 @@ export class MyAppModule {}
 
 ## How It Works
 
-1. `start` queues `AgentWorkflow` with a system prompt and selected tools.
-2. A `LinkDocument` is saved to show embedded progress in Studio.
-3. When the child workflow finishes, `agentComplete` receives callback payload data.
-4. The workflow marks the link as successful and saves the final assistant message.
+1. `start` queues `AgentWorkflow` with a system prompt and selected tools, with `show: 'inline'` so the child is embedded in the parent's run view.
+2. When the child workflow finishes, `agentComplete` receives the callback payload data.
+3. The workflow saves the final assistant message.
 
 ## Public API
 

--- a/registry/examples/agent-example-workflow/src/__tests__/agent-example.workflow.spec.ts
+++ b/registry/examples/agent-example-workflow/src/__tests__/agent-example.workflow.spec.ts
@@ -48,16 +48,7 @@ describe('AgentExampleWorkflow', () => {
         tools: ['weather_lookup', 'calculator'],
         userMessage: expect.any(String),
       }),
-      { callback: { transition: 'agentComplete' } },
-    );
-
-    expect(result.documents).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          documentName: 'link',
-          content: expect.objectContaining({ workflowId: 'agent-sub-id' }),
-        }),
-      ]),
+      { callback: { transition: 'agentComplete' }, show: 'inline', label: 'Agent working...' },
     );
   });
 

--- a/registry/examples/agent-example-workflow/src/agent-example.workflow.ts
+++ b/registry/examples/agent-example-workflow/src/agent-example.workflow.ts
@@ -1,14 +1,6 @@
 import { z } from 'zod';
 import { AgentWorkflow } from '@loopstack/agent';
-import {
-  BaseWorkflow,
-  CallbackSchema,
-  LinkDocument,
-  MessageDocument,
-  QueueResult,
-  Transition,
-  Workflow,
-} from '@loopstack/common';
+import { BaseWorkflow, CallbackSchema, MessageDocument, Transition, Workflow } from '@loopstack/common';
 
 const AgentCallbackSchema = CallbackSchema.extend({
   data: z.object({ response: z.string() }),
@@ -27,19 +19,13 @@ export class AgentExampleWorkflow extends BaseWorkflow {
 
   @Transition({ to: 'running' })
   async start(state: Record<string, unknown>): Promise<Record<string, unknown>> {
-    const result: QueueResult = await this.agentWorkflow.run(
+    await this.agentWorkflow.run(
       {
         system: this.render(__dirname + '/templates/system.md'),
         tools: ['weather_lookup', 'calculator'],
         userMessage: "What's the weather in Tokyo? Also, what is 42 * 17?",
       },
-      { callback: { transition: 'agentComplete' } },
-    );
-
-    await this.documentStore.save(
-      LinkDocument,
-      { label: 'Agent working...', workflowId: result.workflowId, embed: true, expanded: true },
-      { id: `link_${result.workflowId}` },
+      { callback: { transition: 'agentComplete' }, show: 'inline', label: 'Agent working...' },
     );
     return state;
   }
@@ -51,12 +37,6 @@ export class AgentExampleWorkflow extends BaseWorkflow {
     schema: AgentCallbackSchema,
   })
   async agentComplete(state: Record<string, unknown>, payload: AgentCallback): Promise<unknown> {
-    await this.documentStore.save(
-      LinkDocument,
-      { label: 'Agent complete', status: 'success', workflowId: payload.workflowId },
-      { id: `link_${payload.workflowId}` },
-    );
-
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
       text: payload.data.response,

--- a/registry/examples/code-agent-example-workflow/README.md
+++ b/registry/examples/code-agent-example-workflow/README.md
@@ -10,7 +10,7 @@ Demonstrates how to launch the `ExploreAgentWorkflow` from [`@loopstack/code-age
 ## By using this example you'll get...
 
 - A parent workflow that runs `ExploreAgentWorkflow` with a fixed exploration brief
-- A `LinkDocument` that renders the embedded sub-workflow while it runs
+- The embedded sub-workflow rendered inline in the parent's view via `show: 'inline'`
 - A final `MessageDocument` summarizing the agent's findings
 
 ## Installation

--- a/registry/examples/code-agent-example-workflow/src/__tests__/code-agent-example.workflow.spec.ts
+++ b/registry/examples/code-agent-example-workflow/src/__tests__/code-agent-example.workflow.spec.ts
@@ -45,16 +45,7 @@ describe('CodeAgentExampleWorkflow', () => {
         tools: ['glob', 'grep', 'read'],
         userMessage: expect.any(String),
       }),
-      { callback: { transition: 'exploreComplete' } },
-    );
-
-    expect(result.documents).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          documentName: 'link',
-          content: expect.objectContaining({ workflowId: 'sub-id' }),
-        }),
-      ]),
+      { callback: { transition: 'exploreComplete' }, show: 'inline', label: 'Exploring codebase...' },
     );
   });
 

--- a/registry/examples/code-agent-example-workflow/src/code-agent-example.workflow.ts
+++ b/registry/examples/code-agent-example-workflow/src/code-agent-example.workflow.ts
@@ -1,14 +1,6 @@
 import { z } from 'zod';
 import { AgentWorkflow } from '@loopstack/agent';
-import {
-  BaseWorkflow,
-  CallbackSchema,
-  LinkDocument,
-  MessageDocument,
-  QueueResult,
-  Transition,
-  Workflow,
-} from '@loopstack/common';
+import { BaseWorkflow, CallbackSchema, MessageDocument, Transition, Workflow } from '@loopstack/common';
 
 const ExploreCallbackSchema = CallbackSchema.extend({
   data: z.object({ response: z.string() }),
@@ -29,19 +21,13 @@ export class CodeAgentExampleWorkflow extends BaseWorkflow {
 
   @Transition({ to: 'exploring' })
   async startExploration(state: Record<string, unknown>): Promise<Record<string, unknown>> {
-    const result: QueueResult = await this.agentWorkflow.run(
+    await this.agentWorkflow.run(
       {
         system: 'You are a codebase exploration agent. Search and read source code to answer the question thoroughly.',
         tools: ['glob', 'grep', 'read'],
         userMessage: EXPLORE_INSTRUCTIONS,
       },
-      { callback: { transition: 'exploreComplete' } },
-    );
-
-    await this.documentStore.save(
-      LinkDocument,
-      { label: 'Exploring codebase...', workflowId: result.workflowId, embed: true, expanded: true },
-      { id: `link_${result.workflowId}` },
+      { callback: { transition: 'exploreComplete' }, show: 'inline', label: 'Exploring codebase...' },
     );
     return state;
   }
@@ -53,12 +39,6 @@ export class CodeAgentExampleWorkflow extends BaseWorkflow {
     schema: ExploreCallbackSchema,
   })
   async exploreComplete(state: Record<string, unknown>, payload: ExploreCallback): Promise<unknown> {
-    await this.documentStore.save(
-      LinkDocument,
-      { label: 'Exploration complete', status: 'success', workflowId: payload.workflowId },
-      { id: `link_${payload.workflowId}` },
-    );
-
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
       text: payload.data.response,

--- a/registry/examples/github-oauth-example/README.md
+++ b/registry/examples/github-oauth-example/README.md
@@ -40,21 +40,11 @@ The workflow uses `@Guard` to check if authentication is needed and routes to th
 @Transition({ from: 'user_fetched', to: 'awaiting_auth', priority: 10 })
 @Guard('needsAuth')
 async authRequired(state: GitHubReposOverviewState): Promise<GitHubReposOverviewState> {
-  const result = await this.oAuthWorkflow.run(
+  await this.oAuthWorkflow.run(
     { provider: 'github', scopes: ['repo', 'read:org', 'workflow'] },
-    { callback: { transition: 'authCompleted' } },
+    { callback: { transition: 'authCompleted' }, show: 'inline', label: 'GitHub authentication required' },
   );
-
-  await this.documentStore.save(
-    LinkDocument,
-    {
-      label: 'GitHub authentication required',
-      workflowId: result.workflowId,
-      embed: true,
-      expanded: true,
-    },
-    { id: `link_${result.workflowId}` },
-  );
+  return state;
 }
 
 needsAuth(state: GitHubReposOverviewState): boolean {
@@ -71,18 +61,8 @@ The auth callback uses `wait: true` with `CallbackSchema` to receive the OAuth c
   wait: true,
   schema: CallbackSchema,
 })
-async authCompleted(state: GitHubReposOverviewState, payload: { workflowId: string }): Promise<GitHubReposOverviewState> {
-  await this.documentStore.save(
-    LinkDocument,
-    {
-      status: 'success',
-      label: 'GitHub authentication completed',
-      workflowId: payload.workflowId,
-      embed: true,
-      expanded: false,
-    },
-    { id: `link_${payload.workflowId}` },
-  );
+async authCompleted(state: GitHubReposOverviewState, _payload: { workflowId: string }): Promise<GitHubReposOverviewState> {
+  return state;
 }
 ```
 
@@ -234,7 +214,7 @@ ANTHROPIC_API_KEY=your-anthropic-api-key
 
 ## Dependencies
 
-- `@loopstack/common` - Core workflow/runtime APIs (`BaseWorkflow`, `@Workflow`, `@Transition`, `@Guard`, `CallbackSchema`, `ToolResult`, `LinkDocument`, `MarkdownDocument`, `MessageDocument`)
+- `@loopstack/common` - Core workflow/runtime APIs (`BaseWorkflow`, `@Workflow`, `@Transition`, `@Guard`, `CallbackSchema`, `ToolResult`, `MarkdownDocument`, `MessageDocument`)
 - `@loopstack/llm-provider-module` - LLM adapter tools (`LlmGenerateTextTool`, `LlmMessageDocument`, `LlmDelegateToolCallsTool`, `LlmUpdateToolResultTool`)
 - `@loopstack/oauth-module` - OAuth infrastructure (`OAuthWorkflow`)
 - `@loopstack/github-module` - All 25 GitHub tools

--- a/registry/examples/github-oauth-example/src/tools/authenticate-github-task.tool.ts
+++ b/registry/examples/github-oauth-example/src/tools/authenticate-github-task.tool.ts
@@ -1,6 +1,6 @@
 import { Logger } from '@nestjs/common';
 import { z } from 'zod';
-import { BaseTool, LinkDocument, Tool, ToolCallOptions, ToolResult } from '@loopstack/common';
+import { BaseTool, Tool, ToolCallOptions, ToolResult } from '@loopstack/common';
 import type { RunContext } from '@loopstack/common';
 import { OAuthWorkflow } from '@loopstack/oauth-module';
 
@@ -47,19 +47,7 @@ export class AuthenticateGitHubTask extends BaseTool<
   ): Promise<ToolResult<AuthenticateGitHubTaskResult>> {
     const result = await this.oAuthWorkflow.run(
       { provider: 'github', scopes: args.scopes },
-      { callback: options?.callback ?? args.callback },
-    );
-
-    await this.documentStore.save(
-      LinkDocument,
-      {
-        status: 'pending',
-        label: 'GitHub authentication required',
-        workflowId: result.workflowId,
-        embed: true,
-        expanded: true,
-      },
-      { id: `link_${result.workflowId}` },
+      { callback: options?.callback ?? args.callback, show: 'inline', label: 'GitHub authentication required' },
     );
 
     return {
@@ -68,19 +56,7 @@ export class AuthenticateGitHubTask extends BaseTool<
     };
   }
 
-  async complete(result: Record<string, unknown>): Promise<ToolResult<AuthenticateGitHubTaskResult>> {
-    const data = result as { workflowId?: string };
-
-    await this.documentStore.save(
-      LinkDocument,
-      {
-        status: 'success',
-        label: 'GitHub authentication completed',
-        workflowId: data.workflowId,
-      },
-      { id: `link_${data.workflowId}` },
-    );
-
+  async complete(_result: Record<string, unknown>): Promise<ToolResult<AuthenticateGitHubTaskResult>> {
     return {
       data: 'GitHub authentication completed successfully. You can now use GitHub tools.',
     };

--- a/registry/examples/github-oauth-example/src/workflows/github-repos-overview.workflow.ts
+++ b/registry/examples/github-oauth-example/src/workflows/github-repos-overview.workflow.ts
@@ -1,13 +1,5 @@
 import { z } from 'zod';
-import {
-  BaseWorkflow,
-  CallbackSchema,
-  Guard,
-  LinkDocument,
-  MarkdownDocument,
-  Transition,
-  Workflow,
-} from '@loopstack/common';
+import { BaseWorkflow, CallbackSchema, Guard, MarkdownDocument, Transition, Workflow } from '@loopstack/common';
 import type { RunContext } from '@loopstack/common';
 import {
   GitHubGetAuthenticatedUserTool,
@@ -109,20 +101,9 @@ export class GitHubReposOverviewWorkflow extends BaseWorkflow<
   @Transition({ from: 'user_fetched', to: 'awaiting_auth', priority: 10 })
   @Guard('needsAuth')
   async authRequired(state: GitHubReposOverviewState): Promise<GitHubReposOverviewState> {
-    const result = await this.oAuthWorkflow.run(
+    await this.oAuthWorkflow.run(
       { provider: 'github', scopes: ['repo', 'read:org', 'workflow'] },
-      { callback: { transition: 'authCompleted' } },
-    );
-
-    await this.documentStore.save(
-      LinkDocument,
-      {
-        label: 'GitHub authentication required',
-        workflowId: result.workflowId,
-        embed: true,
-        expanded: true,
-      },
-      { id: `link_${result.workflowId}` },
+      { callback: { transition: 'authCompleted' }, show: 'inline', label: 'GitHub authentication required' },
     );
     return state;
   }
@@ -140,19 +121,8 @@ export class GitHubReposOverviewWorkflow extends BaseWorkflow<
   })
   async authCompleted(
     state: GitHubReposOverviewState,
-    payload: { workflowId: string },
+    _payload: { workflowId: string },
   ): Promise<GitHubReposOverviewState> {
-    await this.documentStore.save(
-      LinkDocument,
-      {
-        status: 'success',
-        label: 'GitHub authentication completed',
-        workflowId: payload.workflowId,
-        embed: true,
-        expanded: false,
-      },
-      { id: `link_${payload.workflowId}` },
-    );
     return state;
   }
 

--- a/registry/examples/google-oauth-example/README.md
+++ b/registry/examples/google-oauth-example/README.md
@@ -54,21 +54,11 @@ async fetchEvents(state: CalendarSummaryState, ctx: RunContext): Promise<Calenda
 @Transition({ from: 'calendar_fetched', to: 'awaiting_auth', priority: 10 })
 @Guard('needsAuth')
 async authRequired(state: CalendarSummaryState): Promise<CalendarSummaryState> {
-  const result = await this.oAuthWorkflow.run(
+  await this.oAuthWorkflow.run(
     { provider: 'google', scopes: ['https://www.googleapis.com/auth/calendar.readonly'] },
-    { callback: { transition: 'authCompleted' } },
+    { callback: { transition: 'authCompleted' }, show: 'inline', label: 'Google authentication required' },
   );
-
-  await this.documentStore.save(
-    LinkDocument,
-    {
-      label: 'Google authentication required',
-      workflowId: result.workflowId,
-      embed: true,
-      expanded: true,
-    },
-    { id: `link_${result.workflowId}` },
-  );
+  return state;
 }
 
 needsAuth(state: CalendarSummaryState): boolean {
@@ -85,18 +75,7 @@ The auth callback uses `wait: true` with `CallbackSchema` and transitions back t
   wait: true,
   schema: CallbackSchema,
 })
-async authCompleted(state: CalendarSummaryState, payload: { workflowId: string }): Promise<CalendarSummaryState> {
-  await this.documentStore.save(
-    LinkDocument,
-    {
-      status: 'success',
-      label: 'Google authentication completed',
-      workflowId: payload.workflowId,
-      embed: true,
-      expanded: false,
-    },
-    { id: `link_${payload.workflowId}` },
-  );
+async authCompleted(state: CalendarSummaryState, _payload: { workflowId: string }): Promise<CalendarSummaryState> {
   return state;
 }
 ```
@@ -257,7 +236,7 @@ ANTHROPIC_API_KEY=your-anthropic-api-key
 
 ## Dependencies
 
-- `@loopstack/common` - Core workflow/runtime types and documents (`BaseWorkflow`, `@Workflow`, `@Transition`, `@Guard`, `CallbackSchema`, `LinkDocument`, `MarkdownDocument`)
+- `@loopstack/common` - Core workflow/runtime types and documents (`BaseWorkflow`, `@Workflow`, `@Transition`, `@Guard`, `CallbackSchema`, `MarkdownDocument`)
 - `@loopstack/claude-module` - Claude provider registration used by LLM tools
 - `@loopstack/llm-provider-module` - LLM adapter tools (`LlmGenerateTextTool`, `LlmMessageDocument`, `LlmDelegateToolCallsTool`, `LlmUpdateToolResultTool`)
 - `@loopstack/oauth-module` - OAuth infrastructure (`OAuthWorkflow`, `OAuthTokenStore`)

--- a/registry/examples/google-oauth-example/src/tools/authenticate-google-task.tool.ts
+++ b/registry/examples/google-oauth-example/src/tools/authenticate-google-task.tool.ts
@@ -1,6 +1,6 @@
 import { Logger } from '@nestjs/common';
 import { z } from 'zod';
-import { BaseTool, LinkDocument, Tool, ToolCallOptions, ToolResult } from '@loopstack/common';
+import { BaseTool, Tool, ToolCallOptions, ToolResult } from '@loopstack/common';
 import type { RunContext } from '@loopstack/common';
 import { OAuthWorkflow } from '@loopstack/oauth-module';
 
@@ -49,19 +49,7 @@ export class AuthenticateGoogleTask extends BaseTool<
   ): Promise<ToolResult<AuthenticateGoogleTaskResult>> {
     const result = await this.oAuthWorkflow.run(
       { provider: 'google', scopes: args.scopes },
-      { callback: options?.callback ?? args.callback },
-    );
-
-    await this.documentStore.save(
-      LinkDocument,
-      {
-        status: 'pending',
-        label: 'Google authentication required',
-        workflowId: result.workflowId,
-        embed: true,
-        expanded: true,
-      },
-      { id: `link_${result.workflowId}` },
+      { callback: options?.callback ?? args.callback, show: 'inline', label: 'Google authentication required' },
     );
 
     return {
@@ -70,19 +58,7 @@ export class AuthenticateGoogleTask extends BaseTool<
     };
   }
 
-  async complete(result: Record<string, unknown>): Promise<ToolResult<AuthenticateGoogleTaskResult>> {
-    const data = result as { workflowId?: string };
-
-    await this.documentStore.save(
-      LinkDocument,
-      {
-        status: 'success',
-        label: 'Google authentication completed',
-        workflowId: data.workflowId,
-      },
-      { id: `link_${data.workflowId}` },
-    );
-
+  async complete(_result: Record<string, unknown>): Promise<ToolResult<AuthenticateGoogleTaskResult>> {
     return {
       data: 'Google authentication completed successfully. You can now use Google Workspace tools.',
     };

--- a/registry/examples/google-oauth-example/src/workflows/__tests__/calendar-summary-workflow.spec.ts
+++ b/registry/examples/google-oauth-example/src/workflows/__tests__/calendar-summary-workflow.spec.ts
@@ -152,19 +152,7 @@ describe('CalendarSummaryWorkflow', () => {
       expect(mockOAuthWorkflow.run).toHaveBeenCalledTimes(1);
       expect(mockOAuthWorkflow.run).toHaveBeenCalledWith(
         { provider: 'google', scopes: ['https://www.googleapis.com/auth/calendar.readonly'] },
-        { callback: { transition: 'authCompleted' } },
-      );
-
-      // Link document should have been created for auth flow
-      expect(result.documents).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            documentName: 'link',
-            content: expect.objectContaining({
-              label: 'Google authentication required',
-            }),
-          }),
-        ]),
+        { callback: { transition: 'authCompleted' }, show: 'inline', label: 'Google authentication required' },
       );
     });
 

--- a/registry/examples/google-oauth-example/src/workflows/calendar-summary.workflow.ts
+++ b/registry/examples/google-oauth-example/src/workflows/calendar-summary.workflow.ts
@@ -1,13 +1,5 @@
 import { z } from 'zod';
-import {
-  BaseWorkflow,
-  CallbackSchema,
-  Guard,
-  LinkDocument,
-  MarkdownDocument,
-  Transition,
-  Workflow,
-} from '@loopstack/common';
+import { BaseWorkflow, CallbackSchema, Guard, MarkdownDocument, Transition, Workflow } from '@loopstack/common';
 import type { RunContext } from '@loopstack/common';
 import { OAuthWorkflow } from '@loopstack/oauth-module';
 import { GoogleCalendarFetchEventsTool } from '../tools';
@@ -57,20 +49,9 @@ export class CalendarSummaryWorkflow extends BaseWorkflow<{ calendarId: string }
   @Transition({ from: 'calendar_fetched', to: 'awaiting_auth', priority: 10 })
   @Guard('needsAuth')
   async authRequired(state: CalendarSummaryState): Promise<CalendarSummaryState> {
-    const result = await this.oAuthWorkflow.run(
+    await this.oAuthWorkflow.run(
       { provider: 'google', scopes: ['https://www.googleapis.com/auth/calendar.readonly'] },
-      { callback: { transition: 'authCompleted' } },
-    );
-
-    await this.documentStore.save(
-      LinkDocument,
-      {
-        label: 'Google authentication required',
-        workflowId: result.workflowId,
-        embed: true,
-        expanded: true,
-      },
-      { id: `link_${result.workflowId}` },
+      { callback: { transition: 'authCompleted' }, show: 'inline', label: 'Google authentication required' },
     );
     return state;
   }
@@ -86,18 +67,7 @@ export class CalendarSummaryWorkflow extends BaseWorkflow<{ calendarId: string }
     wait: true,
     schema: CallbackSchema,
   })
-  async authCompleted(state: CalendarSummaryState, payload: { workflowId: string }): Promise<CalendarSummaryState> {
-    await this.documentStore.save(
-      LinkDocument,
-      {
-        status: 'success',
-        label: 'Google authentication completed',
-        workflowId: payload.workflowId,
-        embed: true,
-        expanded: false,
-      },
-      { id: `link_${payload.workflowId}` },
-    );
+  async authCompleted(state: CalendarSummaryState, _payload: { workflowId: string }): Promise<CalendarSummaryState> {
     return state;
   }
 

--- a/registry/examples/hitl-ask-user-example-workflow/src/__tests__/hitl-ask-user-example.workflow.spec.ts
+++ b/registry/examples/hitl-ask-user-example-workflow/src/__tests__/hitl-ask-user-example.workflow.spec.ts
@@ -45,7 +45,7 @@ describe('HitlAskUserExampleWorkflow', () => {
 
     expect(mockAskUserWorkflow.run).toHaveBeenCalledWith(
       { question: 'What is your name?' },
-      { callback: { transition: 'answerReceived' } },
+      { callback: { transition: 'answerReceived' }, show: 'inline', label: 'Waiting for user answer...' },
     );
   });
 

--- a/registry/examples/hitl-ask-user-example-workflow/src/hitl-ask-user-example.workflow.ts
+++ b/registry/examples/hitl-ask-user-example-workflow/src/hitl-ask-user-example.workflow.ts
@@ -1,13 +1,5 @@
 import { z } from 'zod';
-import {
-  BaseWorkflow,
-  CallbackSchema,
-  LinkDocument,
-  MessageDocument,
-  QueueResult,
-  Transition,
-  Workflow,
-} from '@loopstack/common';
+import { BaseWorkflow, CallbackSchema, MessageDocument, QueueResult, Transition, Workflow } from '@loopstack/common';
 import { AskUserWorkflow } from '@loopstack/hitl';
 
 const AskUserCallbackSchema = CallbackSchema.extend({
@@ -28,25 +20,13 @@ export class HitlAskUserExampleWorkflow extends BaseWorkflow {
   async askQuestion(state: Record<string, unknown>): Promise<Record<string, unknown>> {
     const result: QueueResult = await this.askUserWorkflow.run(
       { question: 'What is your name?' },
-      { callback: { transition: 'answerReceived' } },
+      { callback: { transition: 'answerReceived' }, show: 'inline', label: 'Waiting for user answer...' },
     );
 
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
       text: `Asking user a question (sub-workflow ${result.workflowId})...`,
     });
-
-    await this.documentStore.save(
-      LinkDocument,
-      {
-        status: 'pending',
-        label: 'Waiting for user answer...',
-        workflowId: result.workflowId,
-        embed: true,
-        expanded: true,
-      },
-      { id: `link_${result.workflowId}` },
-    );
     return state;
   }
 
@@ -57,18 +37,6 @@ export class HitlAskUserExampleWorkflow extends BaseWorkflow {
     schema: AskUserCallbackSchema,
   })
   async answerReceived(state: Record<string, unknown>, payload: AskUserCallback): Promise<unknown> {
-    await this.documentStore.save(
-      LinkDocument,
-      {
-        status: 'success',
-        label: 'User answered',
-        workflowId: payload.workflowId,
-        embed: true,
-        expanded: false,
-      },
-      { id: `link_${payload.workflowId}` },
-    );
-
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
       text: `Thanks! You answered: ${payload.data.answer}`,

--- a/registry/examples/hitl-confirm-example-workflow/src/__tests__/hitl-confirm-example.workflow.spec.ts
+++ b/registry/examples/hitl-confirm-example-workflow/src/__tests__/hitl-confirm-example.workflow.spec.ts
@@ -41,7 +41,7 @@ describe('HitlConfirmExampleWorkflow', () => {
 
     expect(mockConfirmUserWorkflow.run).toHaveBeenCalledWith(
       expect.objectContaining({ markdown: expect.stringContaining('Ready to deploy') }),
-      { callback: { transition: 'decisionReceived' } },
+      { callback: { transition: 'decisionReceived' }, show: 'inline', label: 'Waiting for user confirmation...' },
     );
   });
 

--- a/registry/examples/hitl-confirm-example-workflow/src/hitl-confirm-example.workflow.ts
+++ b/registry/examples/hitl-confirm-example-workflow/src/hitl-confirm-example.workflow.ts
@@ -1,13 +1,5 @@
 import { z } from 'zod';
-import {
-  BaseWorkflow,
-  CallbackSchema,
-  LinkDocument,
-  MessageDocument,
-  QueueResult,
-  Transition,
-  Workflow,
-} from '@loopstack/common';
+import { BaseWorkflow, CallbackSchema, MessageDocument, QueueResult, Transition, Workflow } from '@loopstack/common';
 import { ConfirmUserWorkflow } from '@loopstack/hitl';
 
 const ConfirmCallbackSchema = CallbackSchema.extend({
@@ -37,25 +29,13 @@ export class HitlConfirmExampleWorkflow extends BaseWorkflow {
   async askForConfirmation(state: Record<string, unknown>): Promise<Record<string, unknown>> {
     const result: QueueResult = await this.confirmUserWorkflow.run(
       { markdown: MARKDOWN_SUMMARY },
-      { callback: { transition: 'decisionReceived' } },
+      { callback: { transition: 'decisionReceived' }, show: 'inline', label: 'Waiting for user confirmation...' },
     );
 
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
       text: `Requesting confirmation (sub-workflow ${result.workflowId})...`,
     });
-
-    await this.documentStore.save(
-      LinkDocument,
-      {
-        status: 'pending',
-        label: 'Waiting for user confirmation...',
-        workflowId: result.workflowId,
-        embed: true,
-        expanded: true,
-      },
-      { id: `link_${result.workflowId}` },
-    );
     return state;
   }
 
@@ -66,18 +46,6 @@ export class HitlConfirmExampleWorkflow extends BaseWorkflow {
     schema: ConfirmCallbackSchema,
   })
   async decisionReceived(state: Record<string, unknown>, payload: ConfirmCallback): Promise<unknown> {
-    await this.documentStore.save(
-      LinkDocument,
-      {
-        status: 'success',
-        label: payload.data.confirmed ? 'User confirmed' : 'User denied',
-        workflowId: payload.workflowId,
-        embed: true,
-        expanded: false,
-      },
-      { id: `link_${payload.workflowId}` },
-    );
-
     const text = payload.data.confirmed ? 'User confirmed — proceeding with deploy.' : 'User denied — aborting.';
 
     await this.documentStore.save(MessageDocument, {

--- a/registry/examples/mcp-linear-example-workflow/src/mcp-linear-example.workflow.ts
+++ b/registry/examples/mcp-linear-example-workflow/src/mcp-linear-example.workflow.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { ChatAgentWorkflow } from '@loopstack/agent';
-import { BaseWorkflow, LinkDocument, MessageDocument, Transition, Workflow } from '@loopstack/common';
+import { BaseWorkflow, MessageDocument, Transition, Workflow } from '@loopstack/common';
 import type { RunContext } from '@loopstack/common';
 import { McpCallTool, McpListToolsTool } from '@loopstack/mcp-module';
 
@@ -41,19 +41,14 @@ export class McpLinearExampleWorkflow extends BaseWorkflow<McpLinearExampleArgs>
       `Always pass serverUrl="${LINEAR_MCP_URL}" and transport="streamableHttp".`,
     ].join('\n');
 
-    const result = await this.chatAgentWorkflow.run({
-      system: systemPrompt,
-      tools: ['mcp_list_tools', 'mcp_call'],
-      userMessage: args.initialMessage,
-    });
-
-    await this.documentStore.save(LinkDocument, {
-      workflowId: result.workflowId,
-      label: 'Linear Agent Chat',
-      status: 'pending',
-      embed: true,
-      expanded: true,
-    });
+    await this.chatAgentWorkflow.run(
+      {
+        system: systemPrompt,
+        tools: ['mcp_list_tools', 'mcp_call'],
+        userMessage: args.initialMessage,
+      },
+      { show: 'inline', label: 'Linear Agent Chat' },
+    );
 
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',

--- a/registry/examples/run-sub-workflow-example/README.md
+++ b/registry/examples/run-sub-workflow-example/README.md
@@ -1,6 +1,6 @@
 ---
 title: Sub-Workflow Example
-description: Example executing child workflows from a parent workflow — workflow.run(), hierarchical workflow composition, callback transitions
+description: Example executing child workflows from a parent workflow — workflow.run(), hierarchical workflow composition, callback transitions, the show option for parent-view rendering
 ---
 
 # @loopstack/run-sub-workflow-example
@@ -11,15 +11,15 @@ This module provides an example demonstrating how to execute child workflows fro
 
 ## Overview
 
-The Run Sub Workflow Example shows how to build workflows that spawn and manage child workflows asynchronously. It demonstrates a parent workflow that starts sub-workflows, tracks their completion status through a callback mechanism, and receives result data from the child workflows.
+The Run Sub Workflow Example shows how to build workflows that spawn and manage child workflows asynchronously. It demonstrates a parent workflow that starts sub-workflows, tracks their completion through a callback mechanism, and receives result data from the child workflows.
 
 By using this example as a reference, you'll learn how to:
 
-- Use `constructor injection of` and `.run()` to start child workflows asynchronously
+- Use constructor injection and `.run()` to start child workflows asynchronously
 - Set up callback transitions to handle sub-workflow completion
 - Define callback schemas with `CallbackSchema.extend()` to type callback payloads
-- Return structured data from sub-workflows via the return value of start `@Transition` methods
-- Display real-time status updates using `LinkDocument`
+- Return structured data from sub-workflows via the return value of the final `@Transition` method
+- Control how a child appears in the parent's run view via the `show` option (`'inline'`, `'link'`, `'hidden'`)
 - Compose complex workflows from smaller, reusable workflow components
 - Chain multiple sequential sub-workflow executions
 
@@ -53,18 +53,20 @@ export class MyAppModule {}
 
 #### Parent Workflow
 
-The parent workflow uses `constructor injection of` to inject the sub-workflow class and calls `.run()` to start it:
+The parent workflow injects the sub-workflow class and calls `.run()` to start it:
 
 ```typescript
 @Workflow({ uiConfig: __dirname + '/run-sub-workflow-example-parent.ui.yaml' })
 export class RunSubWorkflowExampleParentWorkflow extends BaseWorkflow {
-  constructor injection of private runSubWorkflowExampleSub: RunSubWorkflowExampleSubWorkflow;
+  constructor(private readonly subWorkflow: RunSubWorkflowExampleSubWorkflow) {
+    super();
+  }
 }
 ```
 
 #### Sub-Workflow
 
-The sub-workflow returns structured data from its start `@Transition` method. This data is delivered to the parent workflow via the callback payload:
+The sub-workflow returns structured data from its final `@Transition` method. This data is delivered to the parent workflow via the callback payload:
 
 ```typescript
 @Workflow({ uiConfig: __dirname + '/run-sub-workflow-example-sub.ui.yaml' })
@@ -84,24 +86,29 @@ export class RunSubWorkflowExampleSubWorkflow extends BaseWorkflow {
 
 #### 1. Running a Sub-Workflow with Callbacks
 
-Use `.run()` on the injected workflow to start it asynchronously. Pass a `callback` option specifying which transition to trigger when the sub-workflow completes:
+Use `.run()` on the injected workflow to start it asynchronously. Pass a `callback` option specifying which transition to trigger when the sub-workflow completes, and a `show` option to control how the child appears in the parent's run view:
 
 ```typescript
 @Transition({ to: 'sub_workflow_started' })
 async runWorkflow() {
-  const result: QueueResult = await this.runSubWorkflowExampleSub.run(
+  await this.subWorkflow.run(
     {},
-    { alias: 'runSubWorkflowExampleSub', callback: { transition: 'subWorkflowCallback' } },
-  );
-  await this.documentStore.save(
-    LinkDocument,
-    { label: 'Executing Sub-Workflow...', workflowId: result.workflowId },
-    { id: `link_${result.workflowId}` },
+    { callback: { transition: 'subWorkflowCallback' }, show: 'link', label: 'Sub-Workflow' },
   );
 }
 ```
 
-#### 2. Defining Callback Schemas
+#### 2. The `show` Option
+
+`show` controls how the child sub-workflow is rendered inside the parent's run view:
+
+- `'inline'` _(default)_ — embed the child as an inline iframe in the parent's view. Best for HITL/OAuth/interactive children.
+- `'link'` — show a status link card; clicking opens the child in a separate window. Best for autonomous children the parent just tracks.
+- `'hidden'` — no UI at all. Best for background fan-out.
+
+This example uses `show: 'link'` because the sub-workflows run autonomously without needing user interaction.
+
+#### 3. Defining Callback Schemas
 
 Extend `CallbackSchema` to type the callback payload. The base schema includes `workflowId`, and you add your custom `data` shape:
 
@@ -112,18 +119,13 @@ const SubWorkflowCallbackSchema = CallbackSchema.extend({
 type SubWorkflowCallback = z.infer<typeof SubWorkflowCallbackSchema>;
 ```
 
-#### 3. Handling the Callback
+#### 4. Handling the Callback
 
 Define a transition with `wait: true` and the callback schema. The payload contains both the `workflowId` and the `data` returned by the sub-workflow:
 
 ```typescript
 @Transition({ from: 'sub_workflow_started', to: 'sub_workflow_ended', wait: true, schema: SubWorkflowCallbackSchema })
 async subWorkflowCallback(payload: SubWorkflowCallback) {
-  await this.documentStore.save(
-    LinkDocument,
-    { label: 'Sub-Workflow', status: 'success', workflowId: payload.workflowId },
-    { id: `link_${payload.workflowId}` },
-  );
   await this.documentStore.save(MessageDocument, {
     role: 'assistant',
     text: `A message from sub workflow 1: ${payload.data.message}`,
@@ -131,53 +133,21 @@ async subWorkflowCallback(payload: SubWorkflowCallback) {
 }
 ```
 
-#### 4. Displaying Status with LinkDocument
-
-Use `LinkDocument` to display a clickable link to the sub-workflow with status updates:
-
-```typescript
-await this.documentStore.save(
-  LinkDocument,
-  { label: 'Executing Sub-Workflow...', workflowId: result.workflowId },
-  { id: `link_${result.workflowId}` },
-);
-```
-
-After completion, update the same document to show success:
-
-```typescript
-await this.documentStore.save(
-  LinkDocument,
-  { label: 'Sub-Workflow', status: 'success', workflowId: payload.workflowId },
-  { id: `link_${payload.workflowId}` },
-);
-```
-
 #### 5. Chaining Multiple Sub-Workflows
 
-The parent workflow demonstrates running two sub-workflows sequentially. After the first callback completes, a second sub-workflow is started with its own callback. The second callback uses terminal `@Transition` to end the parent workflow:
+The parent workflow demonstrates running two sub-workflows sequentially. After the first callback completes, a second sub-workflow is started with its own callback. The second callback uses a terminal `@Transition` to end the parent workflow:
 
 ```typescript
 @Transition({ from: 'sub_workflow_ended', to: 'sub_workflow2_started' })
 async runWorkflow2() {
-  const result: QueueResult = await this.runSubWorkflowExampleSub.run(
+  await this.subWorkflow.run(
     {},
-    { alias: 'runSubWorkflowExampleSub', callback: { transition: 'subWorkflow2Callback' } },
-  );
-  await this.documentStore.save(
-    LinkDocument,
-    { label: 'Executing Sub-Workflow 2...', workflowId: result.workflowId },
-    { id: `link_${result.workflowId}` },
+    { callback: { transition: 'subWorkflow2Callback' }, show: 'link', label: 'Sub-Workflow 2' },
   );
 }
 
 @Transition({ from: 'sub_workflow2_started', to: 'end', wait: true, schema: SubWorkflowCallbackSchema })
 async subWorkflow2Callback(payload: SubWorkflowCallback) {
-  await this.documentStore.save(
-    LinkDocument,
-    { label: 'Sub-Workflow 2', status: 'success', workflowId: payload.workflowId },
-    { id: `link_${payload.workflowId}` },
-  );
   await this.documentStore.save(MessageDocument, {
     role: 'assistant',
     text: `A message from sub workflow 2: ${payload.data.message}`,
@@ -189,7 +159,7 @@ async subWorkflow2Callback(payload: SubWorkflowCallback) {
 
 This workflow uses the following Loopstack modules:
 
-- `@loopstack/common` - Core workflow/runtime APIs (`BaseWorkflow`, `@Workflow`, `@Transition`, `@InjectWorkflow`, `CallbackSchema`, `QueueResult`, `LinkDocument`, `MessageDocument`)
+- `@loopstack/common` - Core workflow/runtime APIs (`BaseWorkflow`, `@Workflow`, `@Transition`, `CallbackSchema`, `MessageDocument`)
 
 ## About
 

--- a/registry/examples/run-sub-workflow-example/src/__tests__/run-sub-workflow-example-parent.workflow.spec.ts
+++ b/registry/examples/run-sub-workflow-example/src/__tests__/run-sub-workflow-example-parent.workflow.spec.ts
@@ -59,19 +59,9 @@ describe('RunSubWorkflowExampleParentWorkflow', () => {
       expect(result.place).toBe('sub_workflow_started');
 
       expect(mockSubWorkflow.run).toHaveBeenCalledTimes(1);
-      expect(mockSubWorkflow.run).toHaveBeenCalledWith({}, { callback: { transition: 'subWorkflowCallback' } });
-
-      // Link document should have been created
-      expect(result.documents).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            documentName: 'link',
-            content: expect.objectContaining({
-              label: 'Executing Sub-Workflow...',
-              workflowId: 'test-workflow-id',
-            }),
-          }),
-        ]),
+      expect(mockSubWorkflow.run).toHaveBeenCalledWith(
+        {},
+        { callback: { transition: 'subWorkflowCallback' }, show: 'link', label: 'Sub-Workflow' },
       );
     });
 
@@ -119,7 +109,10 @@ describe('RunSubWorkflowExampleParentWorkflow', () => {
 
       // runWorkflow2 fires automatically and calls sub workflow again
       expect(mockSubWorkflow.run).toHaveBeenCalledTimes(1);
-      expect(mockSubWorkflow.run).toHaveBeenCalledWith({}, { callback: { transition: 'subWorkflow2Callback' } });
+      expect(mockSubWorkflow.run).toHaveBeenCalledWith(
+        {},
+        { callback: { transition: 'subWorkflow2Callback' }, show: 'link', label: 'Sub-Workflow 2' },
+      );
     });
 
     it('should execute sub_workflow2_callback when resumed from sub_workflow2_started', async () => {

--- a/registry/examples/run-sub-workflow-example/src/run-sub-workflow-example-parent.workflow.ts
+++ b/registry/examples/run-sub-workflow-example/src/run-sub-workflow-example-parent.workflow.ts
@@ -1,13 +1,5 @@
 import { z } from 'zod';
-import {
-  BaseWorkflow,
-  CallbackSchema,
-  LinkDocument,
-  MessageDocument,
-  QueueResult,
-  Transition,
-  Workflow,
-} from '@loopstack/common';
+import { BaseWorkflow, CallbackSchema, MessageDocument, Transition, Workflow } from '@loopstack/common';
 import { RunSubWorkflowExampleSubWorkflow } from './run-sub-workflow-example-sub.workflow';
 
 const SubWorkflowCallbackSchema = CallbackSchema.extend({
@@ -26,15 +18,9 @@ export class RunSubWorkflowExampleParentWorkflow extends BaseWorkflow {
 
   @Transition({ to: 'sub_workflow_started' })
   async runWorkflow(state: Record<string, unknown>): Promise<Record<string, unknown>> {
-    const result: QueueResult = await this.subWorkflow.run({}, { callback: { transition: 'subWorkflowCallback' } });
-
-    await this.documentStore.save(
-      LinkDocument,
-      {
-        label: 'Executing Sub-Workflow...',
-        workflowId: result.workflowId,
-      },
-      { id: `link_${result.workflowId}` },
+    await this.subWorkflow.run(
+      {},
+      { callback: { transition: 'subWorkflowCallback' }, show: 'link', label: 'Sub-Workflow' },
     );
     return state;
   }
@@ -49,16 +35,6 @@ export class RunSubWorkflowExampleParentWorkflow extends BaseWorkflow {
     state: Record<string, unknown>,
     payload: SubWorkflowCallback,
   ): Promise<Record<string, unknown>> {
-    await this.documentStore.save(
-      LinkDocument,
-      {
-        label: 'Sub-Workflow',
-        status: 'success',
-        workflowId: payload.workflowId,
-      },
-      { id: `link_${payload.workflowId}` },
-    );
-
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
       text: `A message from sub workflow 1: ${payload.data.message}`,
@@ -68,15 +44,9 @@ export class RunSubWorkflowExampleParentWorkflow extends BaseWorkflow {
 
   @Transition({ from: 'sub_workflow_ended', to: 'sub_workflow2_started' })
   async runWorkflow2(state: Record<string, unknown>): Promise<Record<string, unknown>> {
-    const result: QueueResult = await this.subWorkflow.run({}, { callback: { transition: 'subWorkflow2Callback' } });
-
-    await this.documentStore.save(
-      LinkDocument,
-      {
-        label: 'Executing Sub-Workflow 2...',
-        workflowId: result.workflowId,
-      },
-      { id: `link_${result.workflowId}` },
+    await this.subWorkflow.run(
+      {},
+      { callback: { transition: 'subWorkflow2Callback' }, show: 'link', label: 'Sub-Workflow 2' },
     );
     return state;
   }
@@ -88,16 +58,6 @@ export class RunSubWorkflowExampleParentWorkflow extends BaseWorkflow {
     schema: SubWorkflowCallbackSchema,
   })
   async subWorkflow2Callback(state: Record<string, unknown>, payload: SubWorkflowCallback): Promise<unknown> {
-    await this.documentStore.save(
-      LinkDocument,
-      {
-        label: 'Sub-Workflow 2',
-        status: 'success',
-        workflowId: payload.workflowId,
-      },
-      { id: `link_${payload.workflowId}` },
-    );
-
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
       text: `A message from sub workflow 2: ${payload.data.message}`,

--- a/registry/features/agent-module/README.md
+++ b/registry/features/agent-module/README.md
@@ -49,7 +49,7 @@ Launch an agent from any workflow:
 ```typescript
 import { z } from 'zod';
 import { AgentWorkflow } from '@loopstack/agent';
-import { BaseWorkflow, CallbackSchema, LinkDocument, MessageDocument, Transition, Workflow } from '@loopstack/common';
+import { BaseWorkflow, CallbackSchema, MessageDocument, Transition, Workflow } from '@loopstack/common';
 
 const AgentCallbackSchema = CallbackSchema.extend({
   data: z.object({ response: z.string() }),
@@ -65,30 +65,19 @@ export class MyWorkflow extends BaseWorkflow {
 
   @Transition({ to: 'running' })
   async start(state: Record<string, unknown>): Promise<Record<string, unknown>> {
-    const result = await this.agent.run(
+    await this.agent.run(
       {
         system: 'You are a helpful assistant with access to search and summarize tools.',
         tools: ['search', 'summarize'],
         userMessage: 'Find and summarize the latest news about AI.',
       },
-      { callback: { transition: 'agentDone' } },
-    );
-
-    await this.documentStore.save(
-      LinkDocument,
-      { label: 'Agent working...', workflowId: result.workflowId, embed: true, expanded: true },
-      { id: `link_${result.workflowId}` },
+      { callback: { transition: 'agentDone' }, show: 'inline', label: 'Agent working...' },
     );
     return state;
   }
 
   @Transition({ from: 'running', to: 'end', wait: true, schema: AgentCallbackSchema })
   async agentDone(state: Record<string, unknown>, payload: AgentCallback): Promise<unknown> {
-    await this.documentStore.save(
-      LinkDocument,
-      { label: 'Agent complete', status: 'success', workflowId: payload.workflowId },
-      { id: `link_${payload.workflowId}` },
-    );
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
       text: payload.data.response,
@@ -142,7 +131,7 @@ With `taskMode: true`, `AgentFinishTool` is added to the tool set. When the LLM 
 
 ```typescript
 import { ChatAgentWorkflow } from '@loopstack/agent';
-import { BaseWorkflow, LinkDocument, MessageDocument, Transition, Workflow } from '@loopstack/common';
+import { BaseWorkflow, Transition, Workflow } from '@loopstack/common';
 import type { RunContext } from '@loopstack/common';
 
 @Workflow({
@@ -156,18 +145,14 @@ export class MyChatWorkflow extends BaseWorkflow {
 
   @Transition({ to: 'chatting' })
   async startChat(state: Record<string, unknown>): Promise<Record<string, unknown>> {
-    const result = await this.chatAgent.run({
-      system: 'You are a helpful assistant.',
-      tools: ['mcp_list_tools', 'mcp_call'],
-      userMessage: 'What tools are available?',
-    });
-
-    await this.documentStore.save(LinkDocument, {
-      workflowId: result.workflowId,
-      label: 'Chat Agent',
-      embed: true,
-      expanded: true,
-    });
+    await this.chatAgent.run(
+      {
+        system: 'You are a helpful assistant.',
+        tools: ['mcp_list_tools', 'mcp_call'],
+        userMessage: 'What tools are available?',
+      },
+      { show: 'inline', label: 'Chat Agent' },
+    );
     return state;
   }
 }

--- a/registry/features/code-agent-module/README.md
+++ b/registry/features/code-agent-module/README.md
@@ -1,6 +1,6 @@
 ---
 title: Code Agent Module
-description: AI-powered codebase exploration for Loopstack — ExploreTask tool launches AgentWorkflow sub-agent with glob/grep/read tools, CodeAgentModule registration, forFeature() LLM config, LinkDocument embedding, CallbackSchema for sub-workflow completion
+description: AI-powered codebase exploration for Loopstack — ExploreTask tool launches AgentWorkflow sub-agent with glob/grep/read tools, CodeAgentModule registration, forFeature() LLM config, CallbackSchema for sub-workflow completion
 ---
 
 # @loopstack/code-agent
@@ -54,15 +54,7 @@ import { Module } from '@nestjs/common';
 import { z } from 'zod';
 import { AgentWorkflow } from '@loopstack/agent';
 import { CodeAgentModule } from '@loopstack/code-agent';
-import {
-  BaseWorkflow,
-  CallbackSchema,
-  LinkDocument,
-  MessageDocument,
-  QueueResult,
-  Transition,
-  Workflow,
-} from '@loopstack/common';
+import { BaseWorkflow, CallbackSchema, MessageDocument, Transition, Workflow } from '@loopstack/common';
 
 const ExploreCallbackSchema = CallbackSchema.extend({
   data: z.object({ response: z.string() }),
@@ -78,19 +70,13 @@ export class MyWorkflow extends BaseWorkflow {
 
   @Transition({ to: 'exploring' })
   async start(state: Record<string, unknown>): Promise<Record<string, unknown>> {
-    const result: QueueResult = await this.agentWorkflow.run(
+    await this.agentWorkflow.run(
       {
         system: 'You are a codebase exploration agent. Search and read source code to answer the question thoroughly.',
         tools: ['glob', 'grep', 'read'],
         userMessage: 'Find the entry-point module and list its top-level providers.',
       },
-      { callback: { transition: 'onExploreComplete' } },
-    );
-
-    await this.documentStore.save(
-      LinkDocument,
-      { label: 'Exploring codebase...', workflowId: result.workflowId, embed: true, expanded: true },
-      { id: `link_${result.workflowId}` },
+      { callback: { transition: 'onExploreComplete' }, show: 'inline', label: 'Exploring codebase...' },
     );
 
     return state;
@@ -98,12 +84,6 @@ export class MyWorkflow extends BaseWorkflow {
 
   @Transition({ from: 'exploring', to: 'end', wait: true, schema: ExploreCallbackSchema })
   async onExploreComplete(state: Record<string, unknown>, payload: ExploreCallback): Promise<unknown> {
-    await this.documentStore.save(
-      LinkDocument,
-      { label: 'Exploration complete', status: 'success', workflowId: payload.workflowId },
-      { id: `link_${payload.workflowId}` },
-    );
-
     await this.documentStore.save(MessageDocument, {
       role: 'assistant',
       text: payload.data.response,
@@ -133,13 +113,13 @@ start ──► exploring (wait) ──► end
 
 1. The parent workflow calls `agentWorkflow.run()` with a system prompt, tool list, and user message
 2. The `AgentWorkflow` sub-workflow starts its own agent loop: LLM generates text, calls tools (`glob`, `grep`, `read`), loops until it produces a final answer
-3. A `LinkDocument` is saved with `embed: true` and `expanded: true` to show the sub-workflow inline in the UI
+3. The orchestrator renders the sub-workflow inline in the parent's UI based on the `show` option (`'inline'` by default)
 4. When the agent finishes, it calls back to the parent workflow's wait transition with `{ data: { response } }`
 5. The parent receives the synthesized answer and can display it or act on it
 
 ### ExploreTask Tool
 
-The module also provides `ExploreTask`, a tool wrapper around `AgentWorkflow` that can be used by other agents. It handles the sub-workflow launch and `LinkDocument` lifecycle automatically:
+The module also provides `ExploreTask`, a tool wrapper around `AgentWorkflow` that can be used by other agents:
 
 ```
 Parent Agent ──► explore_task tool call ──► AgentWorkflow sub-agent
@@ -151,7 +131,7 @@ Parent Agent ──► explore_task tool call ──► AgentWorkflow sub-agent
                                            ◄── complete() callback
 ```
 
-`ExploreTask` launches the sub-agent, saves a `LinkDocument`, and returns `{ workflowId }` with `pending` status. When the sub-agent completes, `ExploreTask.complete()` updates the link and returns the response text.
+`ExploreTask` launches the sub-agent and returns `{ workflowId }` with `pending` status. The orchestrator renders the sub-agent inline in the parent's view. When the sub-agent completes, `ExploreTask.complete()` returns the response text.
 
 ## Args Reference
 
@@ -246,7 +226,7 @@ CodeAgentModule.forFeature({
 
 ## Related
 
-- [`code-agent-example-workflow`](https://loopstack.ai/docs/registry/examples/code-agent-example-workflow) — full working example showing `AgentWorkflow` with glob/grep/read and `LinkDocument` embedding
+- [`code-agent-example-workflow`](https://loopstack.ai/docs/registry/examples/code-agent-example-workflow) — full working example showing `AgentWorkflow` with glob/grep/read
 - [Agent Workflows](https://loopstack.ai/docs/build/ai/agent-workflows) — how the agent loop, tool resolution, and callbacks work
 - [`@loopstack/agent`](https://loopstack.ai/docs/registry/features/agent-module) — the generic `AgentWorkflow` that powers the code agent
 - [`@loopstack/remote-client`](https://loopstack.ai/docs/registry/features/remote-client-module) — the `glob`, `grep`, and `read` tools used by the agent

--- a/registry/features/code-agent-module/src/tools/explore-task.tool.ts
+++ b/registry/features/code-agent-module/src/tools/explore-task.tool.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { AgentWorkflow } from '@loopstack/agent';
-import { BaseTool, LinkDocument, Tool, ToolCallOptions, ToolResult } from '@loopstack/common';
+import { BaseTool, Tool, ToolCallOptions, ToolResult } from '@loopstack/common';
 import type { RunContext } from '@loopstack/common';
 
 const EXPLORE_SYSTEM_PROMPT = `You are a codebase exploration agent. Your job is to search and read
@@ -54,32 +54,17 @@ export class ExploreTask extends BaseTool<ExploreTaskInput, object, ExploreTaskR
         tools: this.tools,
         userMessage: args.instructions,
       },
-      { callback: options?.callback },
-    );
-
-    const workflowId = result.workflowId;
-
-    await this.documentStore.save(
-      LinkDocument,
-      { status: 'pending', label: 'Exploring...', workflowId, embed: true, expanded: true },
-      { id: 'explore_link' },
+      { callback: options?.callback, show: 'inline', label: 'Exploring...' },
     );
 
     return {
-      data: { workflowId },
-      pending: { workflowId },
+      data: { workflowId: result.workflowId },
+      pending: { workflowId: result.workflowId },
     };
   }
 
   async complete(result: Record<string, unknown>): Promise<ToolResult<ExploreTaskResult>> {
     const data = result as { workflowId?: string; data?: { response?: string } };
-
-    await this.documentStore.save(
-      LinkDocument,
-      { status: 'success', label: 'Exploring complete', workflowId: data.workflowId! },
-      { id: 'explore_link' },
-    );
-
     return { data: data.data?.response ?? result };
   }
 }

--- a/registry/features/github-integration-module/README.md
+++ b/registry/features/github-integration-module/README.md
@@ -44,7 +44,7 @@ Inject `ConnectGitHubWorkflow` into your own workflow and run it as a sub-workfl
 
 ```ts
 import { z } from 'zod';
-import { BaseWorkflow, CallbackSchema, LinkDocument, Transition, Workflow } from '@loopstack/common';
+import { BaseWorkflow, CallbackSchema, Transition, Workflow } from '@loopstack/common';
 import { ConnectGitHubWorkflow } from '@loopstack/github-integration';
 
 @Workflow({
@@ -59,25 +59,15 @@ export class SetupProjectWorkflow extends BaseWorkflow {
 
   @Transition({ to: 'awaiting_github' })
   async start(state: Record<string, never>): Promise<unknown> {
-    const result = await this.connectGitHub.run({}, { callback: { transition: 'onGitHubConnected' } });
-
-    await this.documentStore.save(
-      LinkDocument,
-      { label: 'Connect to GitHub', workflowId: result.workflowId, embed: true, expanded: true },
-      { id: 'link_github' },
+    await this.connectGitHub.run(
+      {},
+      { callback: { transition: 'onGitHubConnected' }, show: 'inline', label: 'Connect to GitHub' },
     );
-
     return state;
   }
 
   @Transition({ from: 'awaiting_github', to: 'end', wait: true, schema: CallbackSchema })
   async onGitHubConnected(state: Record<string, never>, payload: { data: unknown }): Promise<unknown> {
-    await this.documentStore.save(
-      LinkDocument,
-      { label: 'Connect to GitHub', status: 'success', embed: true, expanded: false },
-      { id: 'link_github' },
-    );
-
     return { github: payload.data };
   }
 }
@@ -136,7 +126,7 @@ awaiting_choice ──[callback]──► route_choice
 ### Step-by-step
 
 1. **Check auth** -- calls `GitHubGetAuthenticatedUserTool` to see if the user already has a valid token.
-2. **OAuth** -- if not authenticated, launches `OAuthWorkflow` with `provider: 'github'` and `scopes: ['repo', 'user']`. Displays a sign-in link via `LinkDocument`.
+2. **OAuth** -- if not authenticated, launches `OAuthWorkflow` with `provider: 'github'` and `scopes: ['repo', 'user']`. The sign-in UI is embedded in the parent's run view via the default `show: 'inline'`.
 3. **Repo choice** -- uses `AskUserWorkflow` (HITL) to let the user choose between creating a new repo or connecting an existing one.
 4. **Create or select** -- either calls `GitHubCreateRepoTool` or `GitHubListReposTool` followed by a second HITL prompt to pick from the list.
 5. **Uncommitted changes** -- checks `GitStatusTool` for uncommitted work. If dirty, asks the user whether to auto-commit or cancel.
@@ -178,16 +168,16 @@ No module-level configuration. OAuth credentials are managed by `@loopstack/oaut
 
 ## Dependencies
 
-| Package                    | Role                                                                                                               |
-| -------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `@loopstack/common`        | Framework types, decorators (`@Workflow`, `@Transition`, `@Guard`), documents (`LinkDocument`, `MarkdownDocument`) |
-| `@loopstack/core`          | `ClientMessageService` for dispatching workspace events                                                            |
-| `@loopstack/git-module`    | Git tools: `GitStatusTool`, `GitPushTool`, `GitFetchTool`, `GitRemoteConfigureTool`, `GitConfigUserTool`           |
-| `@loopstack/github-module` | GitHub API tools: `GitHubGetAuthenticatedUserTool`, `GitHubCreateRepoTool`, `GitHubListReposTool`                  |
-| `@loopstack/hitl`          | `AskUserWorkflow` for interactive decision points                                                                  |
-| `@loopstack/oauth-module`  | `OAuthWorkflow` and `OAuthTokenStore` for GitHub authentication                                                    |
-| `@loopstack/remote-client` | `BashTool` for running git commands on the remote server                                                           |
-| `zod`                      | Schema validation                                                                                                  |
+| Package                    | Role                                                                                                     |
+| -------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `@loopstack/common`        | Framework types, decorators (`@Workflow`, `@Transition`, `@Guard`), documents (`MarkdownDocument`)       |
+| `@loopstack/core`          | `ClientMessageService` for dispatching workspace events                                                  |
+| `@loopstack/git-module`    | Git tools: `GitStatusTool`, `GitPushTool`, `GitFetchTool`, `GitRemoteConfigureTool`, `GitConfigUserTool` |
+| `@loopstack/github-module` | GitHub API tools: `GitHubGetAuthenticatedUserTool`, `GitHubCreateRepoTool`, `GitHubListReposTool`        |
+| `@loopstack/hitl`          | `AskUserWorkflow` for interactive decision points                                                        |
+| `@loopstack/oauth-module`  | `OAuthWorkflow` and `OAuthTokenStore` for GitHub authentication                                          |
+| `@loopstack/remote-client` | `BashTool` for running git commands on the remote server                                                 |
+| `zod`                      | Schema validation                                                                                        |
 
 ## Related
 

--- a/registry/features/github-integration-module/src/workflows/connect-github/connect-github.workflow.ts
+++ b/registry/features/github-integration-module/src/workflows/connect-github/connect-github.workflow.ts
@@ -1,14 +1,6 @@
 import { z } from 'zod';
 import type { RunContext } from '@loopstack/common';
-import {
-  BaseWorkflow,
-  CallbackSchema,
-  Guard,
-  LinkDocument,
-  MarkdownDocument,
-  Transition,
-  Workflow,
-} from '@loopstack/common';
+import { BaseWorkflow, CallbackSchema, Guard, MarkdownDocument, Transition, Workflow } from '@loopstack/common';
 import { ClientMessageService } from '@loopstack/core';
 import {
   GitConfigUserTool,
@@ -77,22 +69,10 @@ export class ConnectGitHubWorkflow extends BaseWorkflow<Record<string, never>, C
   @Transition({ from: 'check_auth', to: 'awaiting_auth', priority: 10 })
   @Guard('needsAuth')
   async launchOAuth(state: ConnectGitHubState): Promise<ConnectGitHubState> {
-    const result = await this.oAuth.run(
+    await this.oAuth.run(
       { provider: 'github', scopes: ['repo', 'user'] },
-      { callback: { transition: 'authCompleted' } },
+      { callback: { transition: 'authCompleted' }, show: 'inline', label: 'Sign in with GitHub' },
     );
-
-    await this.documentStore.save(
-      LinkDocument,
-      {
-        label: 'Sign in with GitHub',
-        workflowId: result.workflowId,
-        embed: true,
-        expanded: true,
-      },
-      { id: `link_${result.workflowId}` },
-    );
-
     return state;
   }
 
@@ -101,19 +81,7 @@ export class ConnectGitHubWorkflow extends BaseWorkflow<Record<string, never>, C
   }
 
   @Transition({ from: 'awaiting_auth', to: 'check_auth', wait: true, schema: CallbackSchema })
-  async authCompleted(state: ConnectGitHubState, payload: { workflowId: string }): Promise<ConnectGitHubState> {
-    await this.documentStore.save(
-      LinkDocument,
-      {
-        status: 'success',
-        label: 'GitHub authentication completed',
-        workflowId: payload.workflowId,
-        embed: true,
-        expanded: false,
-      },
-      { id: `link_${payload.workflowId}` },
-    );
-
+  async authCompleted(state: ConnectGitHubState, _payload: { workflowId: string }): Promise<ConnectGitHubState> {
     const result = await this.gitHubGetAuthenticatedUser.call();
     return { ...state, user: result.data!.user, requiresAuth: false };
   }
@@ -122,32 +90,19 @@ export class ConnectGitHubWorkflow extends BaseWorkflow<Record<string, never>, C
 
   @Transition({ from: 'check_auth', to: 'awaiting_choice' })
   async askCreateOrLink(state: ConnectGitHubState): Promise<ConnectGitHubState> {
-    const result = await this.askUser.run(
+    await this.askUser.run(
       {
         question: 'Would you like to create a new GitHub repository or connect an existing one?',
         mode: 'options',
         options: ['Create new repository', 'Connect existing repository'],
       },
-      { callback: { transition: 'choiceReceived' } },
+      { callback: { transition: 'choiceReceived' }, show: 'inline', label: 'Create or connect repository' },
     );
-
-    await this.documentStore.save(
-      LinkDocument,
-      { label: 'Create or connect repository', workflowId: result.workflowId, embed: true, expanded: true },
-      { id: `link_choice` },
-    );
-
     return state;
   }
 
   @Transition({ from: 'awaiting_choice', to: 'route_choice', wait: true, schema: CallbackSchema })
   async choiceReceived(state: ConnectGitHubState, payload: { data: { answer: string } }): Promise<ConnectGitHubState> {
-    await this.documentStore.save(
-      LinkDocument,
-      { label: 'Create or connect repository', status: 'success', embed: true, expanded: false },
-      { id: `link_choice` },
-    );
-
     if (payload.data.answer === 'Connect existing repository') {
       const listResult = await this.gitHubListRepos.call({
         visibility: 'all',
@@ -158,26 +113,14 @@ export class ConnectGitHubWorkflow extends BaseWorkflow<Record<string, never>, C
       const repos = listResult.data!.repos ?? [];
       const repoNames = repos.map((r) => r.fullName);
 
-      const askResult = await this.askUser.run(
+      await this.askUser.run(
         { question: 'Select a repository to connect:', mode: 'options', options: repoNames },
-        { callback: { transition: 'repoSelected' } },
-      );
-
-      await this.documentStore.save(
-        LinkDocument,
-        { label: 'Select repository', workflowId: askResult.workflowId, embed: true, expanded: true },
-        { id: `link_repo_select` },
+        { callback: { transition: 'repoSelected' }, show: 'inline', label: 'Select repository' },
       );
     } else {
-      const askResult = await this.askUser.run(
+      await this.askUser.run(
         { question: 'Enter a name for your new repository:' },
-        { callback: { transition: 'createRepo' } },
-      );
-
-      await this.documentStore.save(
-        LinkDocument,
-        { label: 'Repository name', workflowId: askResult.workflowId, embed: true, expanded: true },
-        { id: `link_repo_name` },
+        { callback: { transition: 'createRepo' }, show: 'inline', label: 'Repository name' },
       );
     }
 
@@ -188,12 +131,6 @@ export class ConnectGitHubWorkflow extends BaseWorkflow<Record<string, never>, C
 
   @Transition({ from: 'route_choice', to: 'configure_remote', wait: true, schema: CallbackSchema })
   async createRepo(state: ConnectGitHubState, payload: { data: { answer: string } }): Promise<ConnectGitHubState> {
-    await this.documentStore.save(
-      LinkDocument,
-      { label: 'Repository name', status: 'success', embed: true, expanded: false },
-      { id: `link_repo_name` },
-    );
-
     const repoName = payload.data.answer.trim();
     const createResult = await this.gitHubCreateRepo.call({
       name: repoName,
@@ -208,12 +145,6 @@ export class ConnectGitHubWorkflow extends BaseWorkflow<Record<string, never>, C
 
   @Transition({ from: 'route_choice', to: 'configure_remote', wait: true, schema: CallbackSchema })
   async repoSelected(state: ConnectGitHubState, payload: { data: { answer: string } }): Promise<ConnectGitHubState> {
-    await this.documentStore.save(
-      LinkDocument,
-      { label: 'Select repository', status: 'success', embed: true, expanded: false },
-      { id: `link_repo_select` },
-    );
-
     const fullName = payload.data.answer;
     const [, name] = fullName.split('/');
 
@@ -269,22 +200,15 @@ export class ConnectGitHubWorkflow extends BaseWorkflow<Record<string, never>, C
   // Uncommitted changes — ask user
   @Transition({ from: 'check_uncommitted', to: 'awaiting_commit_confirm' })
   async askCommitChanges(state: ConnectGitHubState): Promise<ConnectGitHubState> {
-    const confirmResult = await this.askUser.run(
+    await this.askUser.run(
       {
         question:
           'There are uncommitted changes in your workspace. They need to be committed before connecting to a remote repository. Would you like to commit them now?',
         mode: 'options',
         options: ['Commit changes and continue', 'Cancel'],
       },
-      { callback: { transition: 'uncommittedChangesHandled' } },
+      { callback: { transition: 'uncommittedChangesHandled' }, show: 'inline', label: 'Uncommitted changes' },
     );
-
-    await this.documentStore.save(
-      LinkDocument,
-      { label: 'Uncommitted changes', workflowId: confirmResult.workflowId, embed: true, expanded: true },
-      { id: `link_uncommitted` },
-    );
-
     return state;
   }
 
@@ -293,12 +217,6 @@ export class ConnectGitHubWorkflow extends BaseWorkflow<Record<string, never>, C
     state: ConnectGitHubState,
     payload: { data: { answer: string } },
   ): Promise<ConnectGitHubState> {
-    await this.documentStore.save(
-      LinkDocument,
-      { label: 'Uncommitted changes', status: 'success', embed: true, expanded: false },
-      { id: `link_uncommitted` },
-    );
-
     if (payload.data.answer === 'Cancel') {
       return { ...state, repo: undefined };
     }
@@ -392,15 +310,9 @@ export class ConnectGitHubWorkflow extends BaseWorkflow<Record<string, never>, C
           'Cancel (disconnect remote)',
         ];
 
-    const result = await this.askUser.run(
+    await this.askUser.run(
       { question, mode: 'options', options },
-      { callback: { transition: 'syncStrategyChosen' } },
-    );
-
-    await this.documentStore.save(
-      LinkDocument,
-      { label: 'Resolve differences', workflowId: result.workflowId, embed: true, expanded: true },
-      { id: `link_sync` },
+      { callback: { transition: 'syncStrategyChosen' }, show: 'inline', label: 'Resolve differences' },
     );
 
     return state;
@@ -412,12 +324,6 @@ export class ConnectGitHubWorkflow extends BaseWorkflow<Record<string, never>, C
     payload: { data: { answer: string } },
     ctx: RunContext,
   ): Promise<ConnectGitHubState> {
-    await this.documentStore.save(
-      LinkDocument,
-      { label: 'Resolve differences', status: 'success', embed: true, expanded: false },
-      { id: `link_sync` },
-    );
-
     const answer = payload.data.answer;
     const statusResult = await this.gitStatus.call();
     const branch = statusResult.data!.branch ?? 'main';

--- a/registry/features/github-module/README.md
+++ b/registry/features/github-module/README.md
@@ -54,7 +54,7 @@ The fastest way to use GitHub tools is through `AgentWorkflow` — pass tool nam
 
 ```typescript
 import { AgentWorkflow } from '@loopstack/agent';
-import { BaseWorkflow, LinkDocument, Transition, Workflow } from '@loopstack/common';
+import { BaseWorkflow, Transition, Workflow } from '@loopstack/common';
 
 @Workflow({ title: 'GitHub Assistant' })
 export class GitHubAssistantWorkflow extends BaseWorkflow {
@@ -64,7 +64,7 @@ export class GitHubAssistantWorkflow extends BaseWorkflow {
 
   @Transition({ to: 'chatting' })
   async start(state: Record<string, unknown>): Promise<Record<string, unknown>> {
-    const result = await this.agent.run(
+    await this.agent.run(
       {
         system: 'You are a GitHub assistant. Help the user manage repos, issues, PRs, and actions.',
         tools: [
@@ -80,13 +80,7 @@ export class GitHubAssistantWorkflow extends BaseWorkflow {
         ],
         userMessage: 'List my five most recently updated repositories.',
       },
-      { callback: { transition: 'agentDone' } },
-    );
-
-    await this.documentStore.save(
-      LinkDocument,
-      { label: 'Working...', workflowId: result.workflowId, embed: true, expanded: true },
-      { id: `link_${result.workflowId}` },
+      { callback: { transition: 'agentDone' }, show: 'inline', label: 'Working...' },
     );
     return state;
   }
@@ -101,7 +95,7 @@ For full control over the auth flow, inject the individual tools and `OAuthWorkf
 
 ```typescript
 import { z } from 'zod';
-import { BaseWorkflow, CallbackSchema, Guard, LinkDocument, Transition, Workflow } from '@loopstack/common';
+import { BaseWorkflow, CallbackSchema, Guard, Transition, Workflow } from '@loopstack/common';
 import type { RunContext } from '@loopstack/common';
 import { GitHubGetAuthenticatedUserTool, GitHubListReposTool } from '@loopstack/github-module';
 import { OAuthWorkflow } from '@loopstack/oauth-module';
@@ -134,14 +128,9 @@ export class MyGitHubWorkflow extends BaseWorkflow<Record<string, unknown>, Stat
   @Transition({ from: 'user_checked', to: 'awaiting_auth', priority: 10 })
   @Guard('needsAuth')
   async startAuth(state: State): Promise<State> {
-    const result = await this.oAuthWorkflow.run(
+    await this.oAuthWorkflow.run(
       { provider: 'github', scopes: ['repo', 'read:org', 'workflow'] },
-      { callback: { transition: 'authCompleted' } },
-    );
-    await this.documentStore.save(
-      LinkDocument,
-      { label: 'GitHub authentication required', workflowId: result.workflowId, embed: true, expanded: true },
-      { id: `link_${result.workflowId}` },
+      { callback: { transition: 'authCompleted' }, show: 'inline', label: 'GitHub authentication required' },
     );
     return state;
   }

--- a/registry/features/google-workspace-module/README.md
+++ b/registry/features/google-workspace-module/README.md
@@ -52,7 +52,7 @@ Use Google tools in an agent workflow:
 
 ```typescript
 import { AgentWorkflow } from '@loopstack/agent';
-import { BaseWorkflow, LinkDocument, Transition, Workflow } from '@loopstack/common';
+import { BaseWorkflow, Transition, Workflow } from '@loopstack/common';
 
 @Workflow({ title: 'Google Assistant' })
 export class GoogleAssistantWorkflow extends BaseWorkflow {
@@ -62,7 +62,7 @@ export class GoogleAssistantWorkflow extends BaseWorkflow {
 
   @Transition({ to: 'chatting' })
   async start(state: Record<string, unknown>): Promise<Record<string, unknown>> {
-    const result = await this.agent.run(
+    await this.agent.run(
       {
         system: 'You are a Google Workspace assistant with access to Calendar, Gmail, and Drive.',
         tools: [
@@ -80,13 +80,7 @@ export class GoogleAssistantWorkflow extends BaseWorkflow {
         ],
         userMessage: 'Summarize my calendar events for today.',
       },
-      { callback: { transition: 'agentDone' } },
-    );
-
-    await this.documentStore.save(
-      LinkDocument,
-      { label: 'Working...', workflowId: result.workflowId, embed: true, expanded: true },
-      { id: `link_${result.workflowId}` },
+      { callback: { transition: 'agentDone' }, show: 'inline', label: 'Working...' },
     );
     return state;
   }

--- a/registry/features/hitl-module/README.md
+++ b/registry/features/hitl-module/README.md
@@ -41,7 +41,7 @@ export class MyModule {}
 
 ```typescript
 import { z } from 'zod';
-import { BaseWorkflow, CallbackSchema, LinkDocument, MessageDocument, Transition, Workflow } from '@loopstack/common';
+import { BaseWorkflow, CallbackSchema, MessageDocument, Transition, Workflow } from '@loopstack/common';
 import { AskUserWorkflow } from '@loopstack/hitl';
 
 const AnswerCallback = CallbackSchema.extend({
@@ -56,14 +56,9 @@ export class MyWorkflow extends BaseWorkflow {
 
   @Transition({ to: 'waiting' })
   async start(state: Record<string, unknown>): Promise<Record<string, unknown>> {
-    const result = await this.askUser.run(
+    await this.askUser.run(
       { question: 'What is your name?' },
-      { callback: { transition: 'answerReceived' } },
-    );
-    await this.documentStore.save(
-      LinkDocument,
-      { label: 'Waiting for answer...', workflowId: result.workflowId, embed: true, expanded: true },
-      { id: `link_${result.workflowId}` },
+      { callback: { transition: 'answerReceived' }, show: 'inline', label: 'Waiting for answer...' },
     );
     return state;
   }
@@ -228,7 +223,7 @@ Present markdown content to the user for approval. Pauses the agent until the us
 
 ## Dependencies
 
-- `@loopstack/common` — `BaseWorkflow`, `BaseTool`, decorators, `LinkDocument`
+- `@loopstack/common` — `BaseWorkflow`, `BaseTool`, decorators
 - `@loopstack/core` — `LoopCoreModule`
 
 ## Related

--- a/registry/features/hitl-module/src/tools/ask-clarification.tool.ts
+++ b/registry/features/hitl-module/src/tools/ask-clarification.tool.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { BaseTool, LinkDocument, Tool, ToolCallOptions, ToolResult } from '@loopstack/common';
+import { BaseTool, Tool, ToolCallOptions, ToolResult } from '@loopstack/common';
 import type { RunContext } from '@loopstack/common';
 import { AskUserWorkflow } from '../workflows/ask-user/ask-user.workflow.js';
 
@@ -59,32 +59,17 @@ export class AskClarificationTool extends BaseTool<AskClarificationInput, object
         options: args.options,
         allowCustomAnswer: args.allowCustomAnswer,
       },
-      { callback: options?.callback },
-    );
-
-    const workflowId = result.workflowId;
-
-    await this.documentStore.save(
-      LinkDocument,
-      { status: 'pending', label: 'Waiting for user answer...', workflowId, embed: true, expanded: true },
-      { id: `ask_clarification_link_${workflowId}` },
+      { callback: options?.callback, show: 'inline', label: 'Waiting for user answer...' },
     );
 
     return {
-      data: { workflowId },
-      pending: { workflowId },
+      data: { workflowId: result.workflowId },
+      pending: { workflowId: result.workflowId },
     };
   }
 
   async complete(result: Record<string, unknown>): Promise<ToolResult<AskClarificationResult>> {
-    const data = result as { workflowId?: string; data?: { answer?: string } };
-
-    await this.documentStore.save(
-      LinkDocument,
-      { status: 'success', label: 'User answered', workflowId: data.workflowId!, embed: true, expanded: false },
-      { id: `ask_clarification_link_${data.workflowId}` },
-    );
-
+    const data = result as { data?: { answer?: string } };
     return { data: data.data?.answer ?? result };
   }
 }

--- a/registry/features/hitl-module/src/tools/ask-for-approval.tool.ts
+++ b/registry/features/hitl-module/src/tools/ask-for-approval.tool.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { BaseTool, LinkDocument, Tool, ToolCallOptions, ToolResult } from '@loopstack/common';
+import { BaseTool, Tool, ToolCallOptions, ToolResult } from '@loopstack/common';
 import type { RunContext } from '@loopstack/common';
 import { ConfirmUserWorkflow } from '../workflows/confirm-user/confirm-user.workflow.js';
 
@@ -31,38 +31,20 @@ export class AskForApprovalTool extends BaseTool<AskForApprovalInput, object, As
     ctx: RunContext,
     options?: ToolCallOptions,
   ): Promise<ToolResult<AskForApprovalResult>> {
-    const result = await this.confirmUserWorkflow.run({ markdown: args.concept }, { callback: options?.callback });
-
-    const workflowId = result.workflowId;
-
-    await this.documentStore.save(
-      LinkDocument,
-      { status: 'pending', label: 'Waiting for approval...', workflowId, embed: true, expanded: true },
-      { id: `ask_for_approval_link_${workflowId}` },
+    const result = await this.confirmUserWorkflow.run(
+      { markdown: args.concept },
+      { callback: options?.callback, show: 'inline', label: 'Waiting for approval...' },
     );
 
     return {
-      data: { workflowId },
-      pending: { workflowId },
+      data: { workflowId: result.workflowId },
+      pending: { workflowId: result.workflowId },
     };
   }
 
   async complete(result: Record<string, unknown>): Promise<ToolResult<AskForApprovalResult>> {
-    const data = result as { workflowId?: string; data?: { confirmed: boolean; markdown?: string } };
+    const data = result as { data?: { confirmed: boolean; markdown?: string } };
     const approved = data.data?.confirmed ?? false;
-
-    await this.documentStore.save(
-      LinkDocument,
-      {
-        status: approved ? 'success' : 'failure',
-        label: approved ? 'Concept approved' : 'Concept denied',
-        workflowId: data.workflowId!,
-        embed: true,
-        expanded: false,
-      },
-      { id: `ask_for_approval_link_${data.workflowId}` },
-    );
-
     return { data: approved ? { concept: data.data?.markdown } : { denied: true } };
   }
 }

--- a/registry/features/mcp-module/README.md
+++ b/registry/features/mcp-module/README.md
@@ -76,7 +76,7 @@ export class McpLinearModule {}
 // mcp-linear.workflow.ts
 import { z } from 'zod';
 import { ChatAgentWorkflow } from '@loopstack/agent';
-import { BaseWorkflow, LinkDocument, MessageDocument, Transition, Workflow } from '@loopstack/common';
+import { BaseWorkflow, Transition, Workflow } from '@loopstack/common';
 import type { RunContext } from '@loopstack/common';
 import { McpCallTool, McpListToolsTool } from '@loopstack/mcp-module';
 
@@ -102,19 +102,14 @@ export class McpLinearWorkflow extends BaseWorkflow<z.infer<typeof ArgsSchema>> 
   async startChat(state: Record<string, unknown>, ctx: RunContext): Promise<Record<string, unknown>> {
     const args = ctx.args as z.infer<typeof ArgsSchema>;
 
-    const result = await this.chatAgentWorkflow.run({
-      system: 'You are a Linear assistant. Use mcp_list_tools to discover tools, then mcp_call to invoke them.',
-      tools: ['mcp_list_tools', 'mcp_call'],
-      userMessage: args.initialMessage,
-    });
-
-    await this.documentStore.save(LinkDocument, {
-      workflowId: result.workflowId,
-      label: 'Linear Agent Chat',
-      status: 'pending',
-      embed: true,
-      expanded: true,
-    });
+    await this.chatAgentWorkflow.run(
+      {
+        system: 'You are a Linear assistant. Use mcp_list_tools to discover tools, then mcp_call to invoke them.',
+        tools: ['mcp_list_tools', 'mcp_call'],
+        userMessage: args.initialMessage,
+      },
+      { show: 'inline', label: 'Linear Agent Chat' },
+    );
 
     return state;
   }

--- a/registry/features/oauth-module/README.md
+++ b/registry/features/oauth-module/README.md
@@ -39,7 +39,7 @@ export class AppModule {}
 Inject `OAuthWorkflow` into your workflow and launch it as a sub-workflow when authentication is needed:
 
 ```typescript
-import { BaseWorkflow, CallbackSchema, Guard, LinkDocument, Transition, Workflow } from '@loopstack/common';
+import { BaseWorkflow, CallbackSchema, Guard, Transition, Workflow } from '@loopstack/common';
 import type { RunContext } from '@loopstack/common';
 import { OAuthWorkflow } from '@loopstack/oauth-module';
 
@@ -68,20 +68,9 @@ export class CalendarWorkflow extends BaseWorkflow<{ calendarId: string }, Calen
   @Transition({ from: 'calendar_fetched', to: 'awaiting_auth', priority: 10 })
   @Guard('needsAuth')
   async authRequired(state: CalendarState): Promise<CalendarState> {
-    const result = await this.oAuth.run(
+    await this.oAuth.run(
       { provider: 'google', scopes: ['https://www.googleapis.com/auth/calendar.readonly'] },
-      { callback: { transition: 'authCompleted' } },
-    );
-
-    await this.documentStore.save(
-      LinkDocument,
-      {
-        label: 'Google authentication required',
-        workflowId: result.workflowId,
-        embed: true,
-        expanded: true,
-      },
-      { id: `link_${result.workflowId}` },
+      { callback: { transition: 'authCompleted' }, show: 'inline', label: 'Google authentication required' },
     );
     return state;
   }
@@ -91,16 +80,7 @@ export class CalendarWorkflow extends BaseWorkflow<{ calendarId: string }, Calen
   }
 
   @Transition({ from: 'awaiting_auth', to: 'start', wait: true, schema: CallbackSchema })
-  async authCompleted(state: CalendarState, payload: { workflowId: string }): Promise<CalendarState> {
-    await this.documentStore.save(
-      LinkDocument,
-      {
-        status: 'success',
-        label: 'Google authentication completed',
-        workflowId: payload.workflowId,
-      },
-      { id: `link_${payload.workflowId}` },
-    );
+  async authCompleted(state: CalendarState, _payload: { workflowId: string }): Promise<CalendarState> {
     return state;
   }
 
@@ -114,7 +94,7 @@ export class CalendarWorkflow extends BaseWorkflow<{ calendarId: string }, Calen
 }
 ```
 
-The `embed: true` and `expanded: true` flags on the `LinkDocument` render the OAuth sub-workflow inline as an iframe, so the user can complete authentication without leaving the page.
+`show: 'inline'` (the default) renders the OAuth sub-workflow as an embedded iframe in the parent's run view, so the user can complete authentication without leaving the page.
 
 ## How It Works
 

--- a/registry/features/secrets-module/README.md
+++ b/registry/features/secrets-module/README.md
@@ -111,7 +111,7 @@ start ──> requesting_secrets ──(wait)──> verifying ──> end
 
 ### Using RequestSecretsTask in agent workflows
 
-`RequestSecretsTask` is the agent-friendly variant. It launches `SecretsRequestWorkflow` as a sub-workflow with a callback, displays a `LinkDocument` with an embedded view of the sub-workflow, and resolves when the user completes the form. Use this when an LLM agent decides at runtime which secrets to request.
+`RequestSecretsTask` is the agent-friendly variant. It launches `SecretsRequestWorkflow` as a sub-workflow with a callback (rendered inline in the parent's view via the default `show: 'inline'`), and resolves when the user completes the form. Use this when an LLM agent decides at runtime which secrets to request.
 
 ```ts
 import { RequestSecretsTask, GetSecretKeysTool, SecretsRequestWorkflow } from '@loopstack/secrets-module';

--- a/registry/features/secrets-module/src/tools/request-secrets-task.tool.ts
+++ b/registry/features/secrets-module/src/tools/request-secrets-task.tool.ts
@@ -1,6 +1,6 @@
 import { Logger } from '@nestjs/common';
 import { z } from 'zod';
-import { BaseTool, LinkDocument, Tool, ToolCallOptions, ToolResult } from '@loopstack/common';
+import { BaseTool, Tool, ToolCallOptions, ToolResult } from '@loopstack/common';
 import type { RunContext } from '@loopstack/common';
 import { SecretsRequestWorkflow } from './secrets-request.workflow.js';
 
@@ -41,19 +41,7 @@ export class RequestSecretsTask extends BaseTool<RequestSecretsTaskInput, object
   ): Promise<ToolResult<RequestSecretsTaskResult>> {
     const result = await this.secretsRequestWorkflow.run(
       { variables: args.variables },
-      { callback: options?.callback },
-    );
-
-    await this.documentStore.save(
-      LinkDocument,
-      {
-        status: 'pending',
-        label: 'Requesting Secrets',
-        workflowId: result.workflowId,
-        embed: true,
-        expanded: true,
-      },
-      { id: `link_${result.workflowId}` },
+      { callback: options?.callback, show: 'inline', label: 'Requesting Secrets' },
     );
 
     return {
@@ -62,19 +50,7 @@ export class RequestSecretsTask extends BaseTool<RequestSecretsTaskInput, object
     };
   }
 
-  async complete(result: Record<string, unknown>): Promise<ToolResult<RequestSecretsTaskResult>> {
-    const data = result as { workflowId?: string };
-
-    await this.documentStore.save(
-      LinkDocument,
-      {
-        status: 'success',
-        label: 'Secrets have been stored',
-        workflowId: data.workflowId,
-      },
-      { id: `link_${data.workflowId}` },
-    );
-
+  async complete(_result: Record<string, unknown>): Promise<ToolResult<RequestSecretsTaskResult>> {
     return {
       data: 'Secrets have been stored securely by the user.',
     };


### PR DESCRIPTION
Add `show?: 'inline' | 'link' | 'hidden'` (default `'inline'`) and `label?: string` to `RunOptions`. The orchestrator now auto-saves a `LinkDocument` from `queue()` based on `show`, so the parent's run view never goes blank when a sub-workflow is launched. Studio's `LinkCard` reads live status from `useChildWorkflows` rather than a denormalized field, and `LinkDocumentSchema.status` is removed.

All registry features, examples, and sandbox call sites drop their manual `documentStore.save(LinkDocument, …)` pairs around `subWorkflow.run()` in favor of `show` + `label` on the `.run()` call.

Closes #188