### PR TITLE
docs(hitl): correct AskUserWorkflow / ConfirmUserWorkflow return docs

### DIFF
--- a/.changeset/fix-hitl-return-docs.md
+++ b/.changeset/fix-hitl-return-docs.md
@@ -1,0 +1,5 @@
+---
+'@loopstack/hitl': patch
+---
+
+Fix README documentation for `AskUserWorkflow.run()` and `ConfirmUserWorkflow.run()` return values — split the immediate `QueueResult` (`{ workflowId }`) from the callback payload (`{ answer }` / `{ confirmed, markdown }`) and link to the sub-workflow callback example.

--- a/registry/features/hitl-module/README.md
+++ b/registry/features/hitl-module/README.md
@@ -117,7 +117,11 @@ The `show_question` state uses guard-based routing to save the correct document 
 - **options** — saves `AskUserOptionsDocument`, renders a choice list
 - **confirm** — saves `AskUserConfirmDocument`, renders yes/no buttons
 
-**Returns:** `{ answer: string }`
+**Immediate return from `.run()`:** `QueueResult` — `{ workflowId: string }`. `.run()` schedules the child and returns synchronously; it does **not** wait for the user. Use `workflowId` to embed the child in the parent's UI via `LinkDocument` (or pass `show: 'inline'` on `.run()` to do this automatically).
+
+**Callback payload `data`:** `{ answer: string }` — delivered to the wait transition named in `options.callback.transition`, accessed as `payload.data.answer`.
+
+For the full sub-workflow callback pattern — defining a `CallbackSchema`, handling errors via `payload.status`, and embedding the child UI with `show: 'inline'` — see [`@loopstack/run-sub-workflow-example`](https://loopstack.ai/registry/loopstack-run-sub-workflow-example).
 
 #### Multiple-choice and confirmation modes
 
@@ -153,7 +157,9 @@ start → waiting_for_confirmation → end
 
 Two wait transitions (`userConfirmed` / `userDenied`) resolve to different results.
 
-**Returns:** `{ confirmed: boolean, markdown: string }`
+**Immediate return from `.run()`:** `QueueResult` — `{ workflowId: string }`.
+
+**Callback payload `data`:** `{ confirmed: boolean, markdown: string }` — accessed as `payload.data.confirmed` / `payload.data.markdown` in the wait transition.
 
 ```typescript
 import { ConfirmUserWorkflow } from '@loopstack/hitl';
@@ -179,7 +185,8 @@ Both tools follow the same pattern: launch the corresponding sub-workflow, retur
 | `options`           | `string[]`                         | no       | Choices when mode is `'options'`       |
 | `allowCustomAnswer` | `boolean`                          | no       | Show free-text input alongside options |
 
-**Returns:** `{ answer: string }`
+**Immediate return from `.run()`:** `QueueResult` — `{ workflowId: string }`
+**Callback payload `data`:** `{ answer: string }`
 
 ### ConfirmUserWorkflow
 
@@ -187,7 +194,8 @@ Both tools follow the same pattern: launch the corresponding sub-workflow, retur
 | ---------- | -------- | -------- | ----------------------------------- |
 | `markdown` | `string` | yes      | Markdown content to show for review |
 
-**Returns:** `{ confirmed: boolean, markdown: string }`
+**Immediate return from `.run()`:** `QueueResult` — `{ workflowId: string }`
+**Callback payload `data`:** `{ confirmed: boolean, markdown: string }`
 
 ## Tools Reference
 


### PR DESCRIPTION
The README documented the callback payload (`{ answer }`, `{ confirmed, markdown }`) as the return value of `.run()`. `.run()` actually returns `QueueResult { workflowId }` synchronously; the payload arrives later in the wait transition.

- Split the Returns sections into "Immediate return from .run()" and "Callback payload data" for both `AskUserWorkflow` and `ConfirmUserWorkflow`
- Highlight `workflowId` as the input for `LinkDocument` embedding (and the `show: 'inline'` shortcut on `.run()`)
- Cross-link to `@loopstack/run-sub-workflow-example` for the full callback pattern (`CallbackSchema`, `payload.status` error handling, `show` modes)

Closes #195