### PR TITLE
docs(ai): document LlmProviderModule requirement and import ordering

### DIFF
--- a/docs/build/ai/agent-workflows.md
+++ b/docs/build/ai/agent-workflows.md
@@ -19,12 +19,14 @@ Register tools in your module so the agent can use them:
 
 ```typescript
 @Module({
-  imports: [ClaudeModule, AgentModule],
+  imports: [LlmProviderModule, ClaudeModule, AgentModule],
   providers: [GlobTool, GrepTool, ReadTool, MyWorkflow],
   exports: [MyWorkflow],
 })
 export class MyModule {}
 ```
+
+`LlmProviderModule` must be imported alongside any LLM provider module (`ClaudeModule`, `OpenAiModule`) — it registers the global provider registry the adapter tools and provider implementations depend on. See [LLM Providers](./llm-providers.md).
 
 Launch the agent from any workflow:
 

--- a/docs/build/ai/llm-providers.md
+++ b/docs/build/ai/llm-providers.md
@@ -21,6 +21,12 @@ import { LlmProviderModule } from '@loopstack/llm-provider-module';
 export class AppModule {}
 ```
 
+> **`LlmProviderModule` is required, and must be imported before any provider module.**
+>
+> `LlmProviderModule` registers `LlmProviderRegistry` — the runtime registry that provider modules (`ClaudeModule`, `OpenAiModule`) inject to self-register their backends. Importing a provider module without `LlmProviderModule` fails at boot with `UnknownDependenciesException` on `LlmProviderRegistry` (and on `ClaudeLlmProvider` / `OpenAiLlmProvider`, which depend on it).
+>
+> Any of these forms registers the registry: bare `LlmProviderModule`, `LlmProviderModule.forRoot(config)`, or `LlmProviderModule.forFeature(config)` (the feature form imports the global root transitively). Pick `forRoot` when setting app-wide defaults, `forFeature` for per-module overrides, and the bare import when no defaults are needed.
+
 ## Module-Level Defaults
 
 Use `LlmProviderModule.forRoot()` to set a default model for all LLM calls in your app. Use `forFeature()` to override per-module:

--- a/docs/build/ai/text-generation.md
+++ b/docs/build/ai/text-generation.md
@@ -12,14 +12,17 @@ Generate text from any configured LLM provider using `LlmGenerateTextTool`. Pass
 ```typescript
 import { Module } from '@nestjs/common';
 import { ClaudeModule } from '@loopstack/claude-module';
+import { LlmProviderModule } from '@loopstack/llm-provider-module';
 
 @Module({
-  imports: [ClaudeModule],
+  imports: [LlmProviderModule, ClaudeModule],
   providers: [PromptWorkflow],
   exports: [PromptWorkflow],
 })
 export class PromptModule {}
 ```
+
+`LlmProviderModule` registers the global provider registry that adapter tools (`LlmGenerateTextTool`, `LlmGenerateObjectTool`) and provider implementations (`ClaudeLlmProvider`) depend on. Without it, NestJS throws `UnknownDependenciesException` for `LlmProviderRegistry` at boot. See [LLM Providers](./llm-providers.md) for details and module-level defaults.
 
 ## Example Workflow
 


### PR DESCRIPTION
- Add `LlmProviderModule` to setup snippets in `text-generation.md` and `agent-workflows.md` so they boot in a fresh app.
- Add a callout in `llm-providers.md` explaining the ordering constraint, the `UnknownDependenciesException` users hit without it, and the three valid forms (bare, `forRoot`, `forFeature`).

Closes #194