### PR TITLE
feat(studio): align light theme with IntelliJ Light palette

### DIFF
--- a/frontend/studio/src/components/dynamic-form/CodeContent.tsx
+++ b/frontend/studio/src/components/dynamic-form/CodeContent.tsx
@@ -73,11 +73,10 @@ const adaptedPrismDark: Record<string, Record<string, unknown>> = {
   italic: { fontStyle: 'italic' },
 };
 
-const adaptedPrism: Record<string, Record<string, unknown>> = {
+const adaptedPrismLight: Record<string, Record<string, unknown>> = {
   'code[class*="language-"]': {
-    color: 'black',
+    color: '#080808',
     background: 'none',
-    textShadow: '0 1px white',
     fontFamily: "Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace",
     fontSize: '1em',
     textAlign: 'left',
@@ -86,18 +85,11 @@ const adaptedPrism: Record<string, Record<string, unknown>> = {
     wordBreak: 'normal',
     wordWrap: 'normal',
     lineHeight: '1.5',
-    MozTabSize: '4',
-    OTabSize: '4',
     tabSize: '4',
-    WebkitHyphens: 'none',
-    MozHyphens: 'none',
-    msHyphens: 'none',
     hyphens: 'none',
   },
   'pre[class*="language-"]': {
-    color: 'black',
-    // "background": "#f5f2f0",
-    textShadow: '0 1px white',
+    color: '#080808',
     fontFamily: "Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace",
     fontSize: '1em',
     textAlign: 'left',
@@ -106,169 +98,54 @@ const adaptedPrism: Record<string, Record<string, unknown>> = {
     wordBreak: 'normal',
     wordWrap: 'normal',
     lineHeight: '1.5',
-    MozTabSize: '4',
-    OTabSize: '4',
     tabSize: '4',
-    WebkitHyphens: 'none',
-    MozHyphens: 'none',
-    msHyphens: 'none',
     hyphens: 'none',
     padding: '1em',
     margin: '.5em 0',
     overflow: 'auto',
   },
-  'pre[class*="language-"]::-moz-selection': {
-    textShadow: 'none',
-    background: '#b3d4fc',
-  },
-  'pre[class*="language-"] ::-moz-selection': {
-    textShadow: 'none',
-    background: '#b3d4fc',
-  },
-  'code[class*="language-"]::-moz-selection': {
-    textShadow: 'none',
-    background: '#b3d4fc',
-  },
-  'code[class*="language-"] ::-moz-selection': {
-    textShadow: 'none',
-    background: '#b3d4fc',
-  },
-  'pre[class*="language-"]::selection': {
-    textShadow: 'none',
-    background: '#b3d4fc',
-  },
-  'pre[class*="language-"] ::selection': {
-    textShadow: 'none',
-    background: '#b3d4fc',
-  },
-  'code[class*="language-"]::selection': {
-    textShadow: 'none',
-    background: '#b3d4fc',
-  },
-  'code[class*="language-"] ::selection': {
-    textShadow: 'none',
-    background: '#b3d4fc',
-  },
   ':not(pre) > code[class*="language-"]': {
-    // "background": "#f5f2f0",
     padding: '.1em',
     borderRadius: '.3em',
     whiteSpace: 'normal',
   },
-  comment: {
-    color: 'slategray',
-  },
-  prolog: {
-    color: 'slategray',
-  },
-  doctype: {
-    color: 'slategray',
-  },
-  cdata: {
-    color: 'slategray',
-  },
-  punctuation: {
-    color: '#999',
-  },
-  namespace: {
-    opacity: 0.7,
-  },
-  property: {
-    color: '#905',
-  },
-  tag: {
-    color: '#905',
-  },
-  boolean: {
-    color: '#905',
-  },
-  number: {
-    color: '#905',
-  },
-  constant: {
-    color: '#905',
-  },
-  symbol: {
-    color: '#905',
-  },
-  deleted: {
-    color: '#905',
-  },
-  selector: {
-    color: '#690',
-  },
-  'attr-name': {
-    color: '#690',
-  },
-  string: {
-    color: '#690',
-  },
-  char: {
-    color: '#690',
-  },
-  builtin: {
-    color: '#690',
-  },
-  inserted: {
-    color: '#690',
-  },
-  operator: {
-    color: '#9a6e3a',
-    background: 'hsla(0, 0%, 100%, .5)',
-  },
-  entity: {
-    color: '#9a6e3a',
-    background: 'hsla(0, 0%, 100%, .5)',
-    cursor: 'help',
-  },
-  url: {
-    color: '#9a6e3a',
-    background: 'hsla(0, 0%, 100%, .5)',
-  },
-  '.language-css .token.string': {
-    color: '#9a6e3a',
-    background: 'hsla(0, 0%, 100%, .5)',
-  },
-  '.style .token.string': {
-    color: '#9a6e3a',
-    background: 'hsla(0, 0%, 100%, .5)',
-  },
-  atrule: {
-    color: '#07a',
-  },
-  'attr-value': {
-    color: '#07a',
-  },
-  keyword: {
-    color: '#07a',
-  },
-  function: {
-    color: '#DD4A68',
-  },
-  'class-name': {
-    color: '#DD4A68',
-  },
-  regex: {
-    color: '#e90',
-  },
-  important: {
-    color: '#e90',
-    fontWeight: 'bold',
-  },
-  variable: {
-    color: '#e90',
-  },
-  bold: {
-    fontWeight: 'bold',
-  },
-  italic: {
-    fontStyle: 'italic',
-  },
+  comment: { color: '#8c8c8c' },
+  prolog: { color: '#8c8c8c' },
+  doctype: { color: '#8c8c8c' },
+  cdata: { color: '#8c8c8c' },
+  punctuation: { color: '#080808' },
+  namespace: { opacity: 0.7 },
+  property: { color: '#00627a' },
+  tag: { color: '#008077' },
+  boolean: { color: '#871094' },
+  number: { color: '#1750eb' },
+  constant: { color: '#871094' },
+  symbol: { color: '#871094' },
+  deleted: { color: '#871094' },
+  selector: { color: '#067d17' },
+  'attr-name': { color: '#067d17' },
+  string: { color: '#067d17' },
+  char: { color: '#067d17' },
+  builtin: { color: '#067d17' },
+  inserted: { color: '#067d17' },
+  operator: { color: '#080808', background: 'transparent' },
+  entity: { color: '#080808', background: 'transparent', cursor: 'help' },
+  url: { color: '#080808', background: 'transparent' },
+  atrule: { color: '#0033b3' },
+  'attr-value': { color: '#0033b3' },
+  keyword: { color: '#0033b3' },
+  function: { color: '#00627a' },
+  'class-name': { color: '#871094' },
+  regex: { color: '#1750eb' },
+  important: { color: '#1750eb', fontWeight: 'bold' },
+  variable: { color: '#1750eb' },
+  bold: { fontWeight: 'bold' },
+  italic: { fontStyle: 'italic' },
 };
 
 const CodeContent: React.FC<{ content: string }> = ({ content }) => {
   const { theme } = useTheme();
-  const prismStyle = theme === 'dark' ? adaptedPrismDark : adaptedPrism;
+  const prismStyle = theme === 'dark' ? adaptedPrismDark : adaptedPrismLight;
 
   return (
     <Markdown

--- a/frontend/studio/src/styles.css
+++ b/frontend/studio/src/styles.css
@@ -44,37 +44,37 @@
 
 :root {
   --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  --background: #f5f8fe;
+  --foreground: #080808;
+  --card: #ffffff;
+  --card-foreground: #080808;
+  --popover: #ffffff;
+  --popover-foreground: #000000;
+  --primary: #006dcc;
+  --primary-foreground: #ffffff;
+  --secondary: #dfe1e5;
+  --secondary-foreground: #000000;
+  --muted: #ebecf0;
+  --muted-foreground: #6c707e;
+  --accent: #e4e6eb;
+  --accent-foreground: #000000;
+  --destructive: #de1b2e;
+  --border: #d4d4d4;
+  --input: #aeb3c2;
+  --ring: #006dcc;
+  --chart-1: #00627a;
+  --chart-2: #067d17;
+  --chart-3: #0033b3;
+  --chart-4: #871094;
+  --chart-5: #8c4f00;
+  --sidebar: #ebecf0;
+  --sidebar-foreground: #080808;
+  --sidebar-primary: #006dcc;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #e4e6eb;
+  --sidebar-accent-foreground: #000000;
+  --sidebar-border: #d4d4d4;
+  --sidebar-ring: #006dcc;
 }
 
 .dark {


### PR DESCRIPTION
## Summary

Studio's `.dark` theme was previously aligned to IntelliJ's "Island Dark" color scheme. This PR does the same for the light theme, aligning the full app (not just the code editor) to IntelliJ's Light color scheme.

## What changed

**`frontend/studio/src/styles.css`**
- Replaced the default shadcn/oklch placeholder values in `:root` with hex values sourced from IntelliJ Light's editor/syntax colors, mirroring the structural pattern already used by `.dark`:
  - `card`/`popover` (bright content surfaces) vs. `background` (a subtly recessed chrome tone) — same relationship as dark, just inverted polarity.
  - `secondary`/`muted`/`accent` as distinct neutral steps (button bg, subtle sections, hover state).
  - A single accent blue (`#006DCC`, the IDE's link/action color) drives `primary`, `ring`, `sidebar-primary`, and `sidebar-ring`.
  - `destructive` uses the IDE's conflict-status red (`#DE1B2E`).
  - `border`/`input` map to the IDE's separator/line-number tones.
  - `chart-1..5` reuse the IDE's syntax token colors (function/string/keyword/constant/file-status) for hue variety.
- Every value is a hex code that literally appears in the IntelliJ Light color scheme — nothing invented.

**`frontend/studio/src/components/dynamic-form/CodeContent.tsx`**
- The code-block syntax highlighter had a hand-built `adaptedPrismDark` theme (added with the dark-mode work) but still fell back to a generic, unrelated default Prism theme for light mode. Replaced that generic theme with `adaptedPrismLight`, built from the same IntelliJ Light syntax colors used for the new `chart-1..5` tokens, matching the structure/shape of `adaptedPrismDark` exactly.

## What was checked but left unchanged

Audited every other file touched by the original "add dark mode" commit (`StudioSidebar`, `StateNode`, `AiMessageContent`, `ExecutionTimeline`, OAuth pages, etc.). They already reference shadcn tokens (`bg-muted`, `text-muted-foreground`, `border-input`, ...) or carry separate light/dark literals via Tailwind's `dark:` variant, so they inherit the new light palette automatically — no changes needed there.

## How to test

1. `cd frontend/studio && npm run dev`
2. Toggle to light theme via the sidebar theme switch.
3. Check general chrome (background/sidebar/cards/buttons/focus rings) and a markdown code block (e.g. in a chat/document view) for IntelliJ-Light-consistent coloring.
4. `npx tsc -b` passes clean (already verified).

## Risks / follow-ups

- No visual/browser verification was done in this environment (headless sandbox) — only typechecking. Worth a quick manual look before merging.
- Per-role message colors in `CompletionMessagePaper.tsx` (system/user/assistant/etc.) are arbitrary brand colors, not shadcn tokens, and were intentionally left out of scope.
